### PR TITLE
Backport a fix for backspace when caps lock is keymap switcher

### DIFF
--- a/qtbase_5_12_8/0030-fix-backspace-with-capslock-on-linux.patch
+++ b/qtbase_5_12_8/0030-fix-backspace-with-capslock-on-linux.patch
@@ -1,0 +1,19 @@
+diff --git a/src/plugins/platforms/xcb/qxcbkeyboard.cpp b/src/plugins/platforms/xcb/qxcbkeyboard.cpp
+index 3caee3f..5e30f25 100644
+--- a/src/plugins/platforms/xcb/qxcbkeyboard.cpp
++++ b/src/plugins/platforms/xcb/qxcbkeyboard.cpp
+@@ -60,11 +60,11 @@
+         ret |= Qt::ShiftModifier;
+     if (s & XCB_MOD_MASK_CONTROL)
+         ret |= Qt::ControlModifier;
+-    if (s & rmod_masks.alt)
++    if ((s & rmod_masks.alt) == rmod_masks.alt)
+         ret |= Qt::AltModifier;
+-    if (s & rmod_masks.meta)
++    if ((s & rmod_masks.meta) == rmod_masks.meta)
+         ret |= Qt::MetaModifier;
+-    if (s & rmod_masks.altgr)
++    if ((s & rmod_masks.altgr) == rmod_masks.altgr)
+         ret |= Qt::GroupSwitchModifier;
+     return ret;
+ }


### PR DESCRIPTION
Fixes https://github.com/telegramdesktop/tdesktop/issues/2199