### PR TITLE
Patch out GL usage from qtgui main library

### DIFF
--- a/qtbase_5_15_2/0054-no-gl-in-qtgui.patch
+++ b/qtbase_5_15_2/0054-no-gl-in-qtgui.patch
@@ -1,0 +1,13 @@
+diff --git a/src/gui/opengl/qopenglpaintengine.cpp b/src/gui/opengl/qopenglpaintengine.cpp
+index 13c72626ec..f835019136 100644
+--- a/src/gui/opengl/qopenglpaintengine.cpp
++++ b/src/gui/opengl/qopenglpaintengine.cpp
+@@ -686,7 +686,7 @@ void QOpenGL2PaintEngineEx::beginNativePainting()
+     for (int i = 0; i < QT_GL_VERTEX_ARRAY_TRACKED_COUNT; ++i)
+         d->funcs.glDisableVertexAttribArray(i);
+ 
+-#if !defined(QT_OPENGL_ES_2) && !defined(QT_OPENGL_DYNAMIC)
++#if 0
+     Q_ASSERT(QOpenGLContext::currentContext());
+     const QOpenGLContext *ctx = d->ctx;
+     const QSurfaceFormat &fmt = d->device->context()->format();


### PR DESCRIPTION
It's used only for a hack tdesktop doesn't need, patching it out allows to run without GL libraries with shared link since all the other GL usage goes thorugh Qt plugin system