### PR TITLE
Port patches to Qt 6

### DIFF
--- a/qtbase_6_2_0/0001-qt-patched-define.patch
+++ b/qtbase_6_2_0/0001-qt-patched-define.patch
@@ -1,0 +1,13 @@
+diff --git a/src/corelib/global/qglobal.h b/src/corelib/global/qglobal.h
+index ccab228804..e4313a2f14 100644
+--- a/src/corelib/global/qglobal.h
++++ b/src/corelib/global/qglobal.h
+@@ -51,6 +51,8 @@
+ #  include <stddef.h>
+ #endif
+ 
++#define DESKTOP_APP_QT_PATCHED
++
+ /*
+    QT_VERSION is (major << 16) + (minor << 8) + patch.
+ */

--- a/qtbase_6_2_0/0002-disable-slow-debug-code.patch
+++ b/qtbase_6_2_0/0002-disable-slow-debug-code.patch
@@ -1,0 +1,14 @@
+diff --git a/src/corelib/kernel/qcore_mac.mm b/src/corelib/kernel/qcore_mac.mm
+index 266faca0ed..38a559877e 100644
+--- a/src/corelib/kernel/qcore_mac.mm
++++ b/src/corelib/kernel/qcore_mac.mm
+@@ -140,7 +140,8 @@ QMacAutoReleasePool::QMacAutoReleasePool()
+ {
+     Class trackerClass = [QMacAutoReleasePoolTracker class];
+ 
+-#ifdef QT_DEBUG
++// Patch: Disable this debug code because it is very slow.
++#if 0
+     void *poolFrame = nullptr;
+     if (__builtin_available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 5.0, *)) {
+         void *frame;

--- a/qtbase_6_2_0/0003-spellcheck-underline-from-chrome.patch
+++ b/qtbase_6_2_0/0003-spellcheck-underline-from-chrome.patch
@@ -1,0 +1,140 @@
+diff --git a/src/gui/painting/qpainter.cpp b/src/gui/painting/qpainter.cpp
+index 01400a0bc8..a0a6df372c 100644
+--- a/src/gui/painting/qpainter.cpp
++++ b/src/gui/painting/qpainter.cpp
+@@ -5990,6 +5990,91 @@ static QPixmap generateWavyPixmap(qreal maxRadius, const QPen &pen)
+     return pixmap;
+ }
+ 
++// Patch: Improved underline with SpellCheck style for macOS and Windows.
++// Added implementation of underline drawing from Chrome.
++static QPixmap generateChromeSpellcheckPixmap(qreal descent, qreal factor, const QPen &pen) {
++    QString key = QLatin1String("ChromeUnderline-")
++        % pen.color().name()
++        % HexString<qreal>(factor)
++        % HexString<qreal>(pen.widthF());
++
++    QPixmap pixmap;
++    if (QPixmapCache::find(key, &pixmap)) {
++        return pixmap;
++    }
++    // https://chromium.googlesource.com/chromium/src/+/refs/heads/master/third_party/blink/renderer/core/paint/document_marker_painter.cc
++
++#ifdef Q_OS_MAC
++
++    constexpr qreal kMarkerHeight = 3;
++
++    const qreal height = kMarkerHeight * factor;
++    const qreal width = height * 2;
++
++    pixmap = QPixmap(qCeil(width), qFloor(height) * 2);
++    pixmap.setDevicePixelRatio(qApp->devicePixelRatio());
++    pixmap.fill(Qt::transparent);
++    {
++        QPainter imgPainter(&pixmap);
++        imgPainter.setPen(Qt::NoPen);
++        imgPainter.setBrush(pen.color());
++        imgPainter.setRenderHints(
++            QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
++        imgPainter.drawEllipse(0, 0, qFloor(height), qFloor(height));
++    }
++
++#else
++
++    constexpr qreal kMarkerWidth = 4;
++    constexpr qreal kMarkerHeight = 2;
++
++    const auto x1 = (kMarkerWidth * -3 / 8) * factor;
++    const auto y1 = (kMarkerHeight * 3 / 4) * factor;
++
++    const auto cY = (kMarkerHeight * 1 / 4) * factor;
++
++    const auto c1X1 = (kMarkerWidth * -1 / 8) * factor;
++    const auto c1X2 = (kMarkerWidth * 3 / 8) * factor;
++    const auto c1X3 = (kMarkerWidth * 7 / 8) * factor;
++
++    const auto c2X1 = (kMarkerWidth * 1 / 8) * factor;
++    const auto c2X2 = (kMarkerWidth * 5 / 8) * factor;
++    const auto c2X3 = (kMarkerWidth * 9 / 8) * factor;
++
++    QPainterPath path;
++    path.moveTo(x1, y1);
++    path.cubicTo(c1X1, y1,
++        c1X1, cY,
++        c2X1, cY);
++    path.cubicTo(c1X2, cY,
++        c1X2, y1,
++        c2X2, y1);
++    path.cubicTo(c1X3, y1,
++        c1X3, cY,
++        c2X3, cY);
++
++    pixmap = QPixmap(kMarkerWidth * factor, kMarkerHeight * factor * 2);
++    pixmap.fill(Qt::transparent);
++    {
++        QPen wavePen = pen;
++        wavePen.setCapStyle(Qt::RoundCap);
++        wavePen.setJoinStyle(Qt::RoundJoin);
++        wavePen.setWidthF(1 * factor);
++
++        QPainter imgPainter(&pixmap);
++        imgPainter.setPen(std::move(wavePen));
++        imgPainter.setRenderHint(QPainter::Antialiasing);
++        imgPainter.translate(0, descent - (kMarkerHeight * factor));
++        imgPainter.drawPath(std::move(path));
++    }
++
++#endif
++
++    QPixmapCache::insert(std::move(key), pixmap);
++
++    return pixmap;
++}
++
+ static void drawTextItemDecoration(QPainter *painter, const QPointF &pos, const QFontEngine *fe, QTextEngine *textEngine,
+                                    QTextCharFormat::UnderlineStyle underlineStyle,
+                                    QTextItem::RenderFlags flags, qreal width,
+@@ -6007,18 +6092,36 @@ static void drawTextItemDecoration(QPainter *painter, const QPointF &pos, const
+     pen.setWidthF(fe->lineThickness().toReal());
+     pen.setCapStyle(Qt::FlatCap);
+ 
+-    QLineF line(qFloor(pos.x()), pos.y(), qFloor(pos.x() + width), pos.y());
++    // Patch: Improved underline with SpellCheck style for macOS and Windows.
++    // Slightly move the beginning of the underline to the right.
++    QLineF line(qFloor(pos.x() + 1), pos.y(), qFloor(pos.x() + width), pos.y());
+ 
+     const qreal underlineOffset = fe->underlinePosition().toReal();
+ 
+     if (underlineStyle == QTextCharFormat::SpellCheckUnderline) {
+-        QPlatformTheme *theme = QGuiApplicationPrivate::platformTheme();
+-        if (theme)
+-            underlineStyle = QTextCharFormat::UnderlineStyle(theme->themeHint(QPlatformTheme::SpellCheckUnderlineStyle).toInt());
+-        if (underlineStyle == QTextCharFormat::SpellCheckUnderline) // still not resolved
+-            underlineStyle = QTextCharFormat::WaveUnderline;
+-    }
++        const qreal fontFactor = qreal(charFormat.font().pixelSize()) / qreal(10.);
++        painter->save();
++        painter->translate(0, pos.y() + 1);
++        const qreal maxHeight = fe->descent().toReal() - qreal(1);
++
++        QColor uc = charFormat.underlineColor();
++        if (uc.isValid())
++            pen.setColor(uc);
+ 
++        const QPixmap wave = generateChromeSpellcheckPixmap(maxHeight, fontFactor, pen);
++        const int descent = qFloor(maxHeight);
++
++        painter->setBrushOrigin(painter->brushOrigin().x(), 0);
++#ifdef Q_OS_MAC
++        const auto h = wave.height() / 2;
++        painter->drawTiledPixmap(
++            QRectF(pos.x(), (descent - h) / 2., qCeil(width), h),
++            wave);
++#else
++        painter->fillRect(pos.x(), 0, qCeil(width), descent, wave);
++#endif
++        painter->restore();
++    } else
+     if (underlineStyle == QTextCharFormat::WaveUnderline) {
+         painter->save();
+         painter->translate(0, pos.y() + 1);

--- a/qtbase_6_2_0/0004-improve-apostrophe-processing.patch
+++ b/qtbase_6_2_0/0004-improve-apostrophe-processing.patch
@@ -1,0 +1,167 @@
+diff --git a/src/gui/text/qtextcursor.cpp b/src/gui/text/qtextcursor.cpp
+index c88497840f..b08e05cb16 100644
+--- a/src/gui/text/qtextcursor.cpp
++++ b/src/gui/text/qtextcursor.cpp
+@@ -510,6 +510,9 @@ bool QTextCursorPrivate::movePosition(QTextCursor::MoveOperation op, QTextCursor
+         const int len = blockIt.length() - 1;
+         if (relativePos >= len)
+             return false;
++        // Patch: Improved apostrophe processing.
++        relativePos = engine->toEdge(relativePos, len, true);
++#if 0
+         if (engine->atWordSeparator(relativePos)) {
+             ++relativePos;
+             while (relativePos < len && engine->atWordSeparator(relativePos))
+@@ -518,6 +521,7 @@ bool QTextCursorPrivate::movePosition(QTextCursor::MoveOperation op, QTextCursor
+             while (relativePos < len && !attributes[relativePos].whiteSpace && !engine->atWordSeparator(relativePos))
+                 ++relativePos;
+         }
++#endif
+         newPosition = blockIt.position() + relativePos;
+         break;
+     }
+diff --git a/src/gui/text/qtextengine.cpp b/src/gui/text/qtextengine.cpp
+index a7834587b1..cabe897268 100644
+--- a/src/gui/text/qtextengine.cpp
++++ b/src/gui/text/qtextengine.cpp
+@@ -3028,7 +3028,8 @@ bool QTextEngine::atWordSeparator(int position) const
+     case '&':
+     case '^':
+     case '*':
+-    case '\'':
++    // Patch: Make the apostrophe a non-separator for words.
++    //case '\'':
+     case '"':
+     case '`':
+     case '~':
+@@ -3041,6 +3042,74 @@ bool QTextEngine::atWordSeparator(int position) const
+     return false;
+ }
+ 
++// Patch: Improved apostrophe processing.
++// We should consider apostrophes as word separators when there is more than
++// one apostrophe in a row, or when the apostrophe is at the beginning or end
++// of the word.
++int QTextEngine::toEdge(int pos, int len, bool isRightDirection) {
++    const auto step = isRightDirection ? 1 : -1;
++    const auto next = isRightDirection ? 0 : -1;
++
++    QCharAttributes *attributes = const_cast<QCharAttributes *>(this->attributes());
++
++    const auto atApostrophe = [&](int position) {
++        return layoutData->string.at(position).unicode() == '\'';
++    };
++
++    const auto atSepOrApost = [&](int position) {
++        return atApostrophe(position) || atWordSeparator(position);
++    };
++
++    const auto inBounds = [&](int position) {
++        return isRightDirection
++            ? position < len
++            : position > 0;
++    };
++
++    const auto atSepOrSpace = [&](int position) {
++        return attributes[position].whiteSpace || atWordSeparator(position);
++    };
++
++    const auto isApostropheInWord = [&](int position) {
++        if (!atApostrophe(position)) {
++            return false;
++        }
++        auto p = position - 1;
++        if (p <= 0 || atSepOrSpace(p)) {
++            return false;
++        }
++        p = position + 1;
++        if (p >= len || atSepOrSpace(p)) {
++            return false;
++        }
++        return true;
++    };
++
++    auto counter = 0;
++    while (inBounds(pos) && atSepOrApost(pos + next)) {
++        counter++;
++        pos += step;
++    }
++    // If it's not the single apostrophe, then that's non-letter part of text.
++    if (counter > 1 || (counter == 1 && !isApostropheInWord(pos - step + next))) {
++        return pos;
++    }
++
++    bool isPrevApostrophe = false;
++    while (inBounds(pos) && !atSepOrSpace(pos + next)) {
++        bool isNextApostrophe = atApostrophe(pos + next);
++        if (isPrevApostrophe && isNextApostrophe) {
++            break;
++        }
++        pos += step;
++        isPrevApostrophe = isNextApostrophe;
++    }
++    if (isPrevApostrophe) {
++        pos += -step;
++    }
++    return pos;
++}
++
+ void QTextEngine::setPreeditArea(int position, const QString &preeditText)
+ {
+     if (preeditText.isEmpty()) {
+diff --git a/src/gui/text/qtextengine_p.h b/src/gui/text/qtextengine_p.h
+index e9187ea605..51997ba066 100644
+--- a/src/gui/text/qtextengine_p.h
++++ b/src/gui/text/qtextengine_p.h
+@@ -622,6 +622,8 @@ private:
+ 
+ public:
+     bool atWordSeparator(int position) const;
++    // Patch: Improved apostrophe processing.
++    int toEdge(int pos, int len, bool isRightDirection);
+ 
+     QString elidedText(Qt::TextElideMode mode, const QFixed &width, int flags = 0, int from = 0, int count = -1) const;
+ 
+diff --git a/src/gui/text/qtextlayout.cpp b/src/gui/text/qtextlayout.cpp
+index f3f0caa379..a9b34e2b6f 100644
+--- a/src/gui/text/qtextlayout.cpp
++++ b/src/gui/text/qtextlayout.cpp
+@@ -706,6 +706,12 @@ int QTextLayout::nextCursorPosition(int oldPos, CursorMode mode) const
+         while (oldPos < len && !attributes[oldPos].graphemeBoundary)
+             oldPos++;
+     } else {
++        // Patch: Skip to the end of the current word, not to the start of the next one.
++        while (oldPos < len && attributes[oldPos].whiteSpace)
++            oldPos++;
++        // Patch: Improved apostrophe processing.
++        oldPos = d->toEdge(oldPos, len, true);
++#if 0
+         if (oldPos < len && d->atWordSeparator(oldPos)) {
+             oldPos++;
+             while (oldPos < len && d->atWordSeparator(oldPos))
+@@ -716,6 +722,7 @@ int QTextLayout::nextCursorPosition(int oldPos, CursorMode mode) const
+         }
+         while (oldPos < len && attributes[oldPos].whiteSpace)
+             oldPos++;
++#endif
+     }
+ 
+     return oldPos;
+@@ -745,6 +752,9 @@ int QTextLayout::previousCursorPosition(int oldPos, CursorMode mode) const
+         while (oldPos > 0 && attributes[oldPos - 1].whiteSpace)
+             oldPos--;
+ 
++        // Patch: Improved apostrophe processing.
++        oldPos = d->toEdge(oldPos, len, false);
++#if 0
+         if (oldPos && d->atWordSeparator(oldPos-1)) {
+             oldPos--;
+             while (oldPos && d->atWordSeparator(oldPos-1))
+@@ -753,6 +763,7 @@ int QTextLayout::previousCursorPosition(int oldPos, CursorMode mode) const
+             while (oldPos > 0 && !attributes[oldPos - 1].whiteSpace && !d->atWordSeparator(oldPos-1))
+                 oldPos--;
+         }
++#endif
+     }
+ 
+     return oldPos;

--- a/qtbase_6_2_0/0005-fix-shortcuts-on-macos.patch
+++ b/qtbase_6_2_0/0005-fix-shortcuts-on-macos.patch
@@ -1,0 +1,59 @@
+diff --git a/src/gui/platform/darwin/qapplekeymapper.mm b/src/gui/platform/darwin/qapplekeymapper.mm
+index bdf741573d..e2b0c30595 100644
+--- a/src/gui/platform/darwin/qapplekeymapper.mm
++++ b/src/gui/platform/darwin/qapplekeymapper.mm
+@@ -606,10 +606,8 @@ QList<int> QAppleKeyMapper::possibleKeys(const QKeyEvent *event) const
+         // or are a superset of the current candidate modifiers.
+         auto candidateModifiers = modifierCombinations[i];
+         if ((eventModifiers & candidateModifiers) == candidateModifiers) {
+-            // If the event includes more modifiers than the candidate they
+-            // will need to be included in the resulting key combination.
+-            auto additionalModifiers = eventModifiers & ~candidateModifiers;
+-            ret << int(additionalModifiers) + int(keyAfterApplyingModifiers);
++            // Patch: Fix non-english layout global shortcuts.
++            ret << int(additionalModifiers) + int(candidateModifiers);
+         }
+     }
+ 
+diff --git a/src/plugins/platforms/cocoa/qnsview_keys.mm b/src/plugins/platforms/cocoa/qnsview_keys.mm
+index dbcab6c6d1..ead83f31cc 100644
+--- a/src/plugins/platforms/cocoa/qnsview_keys.mm
++++ b/src/plugins/platforms/cocoa/qnsview_keys.mm
+@@ -161,6 +161,23 @@
+         [super keyUp:nsevent];
+ }
+ 
++// Patch: Enable Ctrl+Tab and Ctrl+Shift+Tab / Ctrl+Backtab handle in-app.
++- (BOOL)performKeyEquivalent:(NSEvent *)nsevent
++{
++    NSString *chars = [nsevent charactersIgnoringModifiers];
++
++    if ([nsevent type] == NSKeyDown && [chars length] > 0) {
++        QChar ch = [chars characterAtIndex:0];
++        Qt::Key qtKey = qt_mac_cocoaKey2QtKey(ch);
++        if ([nsevent modifierFlags] & NSControlKeyMask
++                && (qtKey == Qt::Key_Tab || qtKey == Qt::Key_Backtab)) {
++            [self handleKeyEvent:nsevent eventType:int(QEvent::KeyPress)];
++            return YES;
++        }
++    }
++    return [super performKeyEquivalent:nsevent];
++}
++
+ - (void)cancelOperation:(id)sender
+ {
+     Q_UNUSED(sender);
+diff --git a/src/widgets/kernel/qwidget.cpp b/src/widgets/kernel/qwidget.cpp
+index f56fe8559d..200d8b2a3b 100644
+--- a/src/widgets/kernel/qwidget.cpp
++++ b/src/widgets/kernel/qwidget.cpp
+@@ -8712,7 +8712,8 @@ bool QWidget::event(QEvent *event)
+     case QEvent::KeyPress: {
+         QKeyEvent *k = (QKeyEvent *)event;
+         bool res = false;
+-        if (!(k->modifiers() & (Qt::ControlModifier | Qt::AltModifier))) {  //### Add MetaModifier?
++        // Patch: Enable Ctrl+Tab and Ctrl+Shift+Tab / Ctrl+Backtab handle in-app.
++        if (!(k->modifiers() & (Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier))) {
+             if (k->key() == Qt::Key_Backtab
+                 || (k->key() == Qt::Key_Tab && (k->modifiers() & Qt::ShiftModifier)))
+                 res = focusNextPrevChild(false);

--- a/qtbase_6_2_0/0006-allow-creating-floating-panels-macos.patch
+++ b/qtbase_6_2_0/0006-allow-creating-floating-panels-macos.patch
@@ -1,0 +1,20 @@
+diff --git a/src/plugins/platforms/cocoa/qcocoawindow.mm b/src/plugins/platforms/cocoa/qcocoawindow.mm
+index d4c1593936..2b7df1078a 100644
+--- a/src/plugins/platforms/cocoa/qcocoawindow.mm
++++ b/src/plugins/platforms/cocoa/qcocoawindow.mm
+@@ -526,6 +526,15 @@ NSUInteger QCocoaWindow::windowStyleMask(Qt::WindowFlags flags)
+     // Select base window type. Note that the value of NSBorderlessWindowMask is 0.
+     NSUInteger styleMask = (frameless || !resizable) ? NSWindowStyleMaskBorderless : NSWindowStyleMaskResizable;
+ 
++    // Patch: allow creating panels floating on all spaces in macOS.
++    // If you call "setCollectionBehavior:NSWindowCollectionBehaviorFullScreenAuxiliary" before
++    // setting the "NSWindowStyleMaskNonactivatingPanel" bit in the style mask it won't work after that.
++    // So we need a way to set that bit before Qt sets collection behavior the way it does.
++    QVariant nonactivatingPanelMask = window()->property("_td_macNonactivatingPanelMask");
++    if (nonactivatingPanelMask.isValid() && nonactivatingPanelMask.toBool()) {
++        styleMask |= NSWindowStyleMaskNonactivatingPanel;
++    }
++
+     if (frameless) {
+         // Frameless windows do not display the traffic lights buttons for
+         // e.g. minimize, however StyleMaskMiniaturizable is required to allow

--- a/qtbase_6_2_0/0007-fix-file-dialog-on-windows.patch
+++ b/qtbase_6_2_0/0007-fix-file-dialog-on-windows.patch
@@ -1,0 +1,30 @@
+diff --git a/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp b/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp
+index 6fc90035ed..b34f8623bb 100644
+--- a/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp
++++ b/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp
+@@ -1174,7 +1174,14 @@ void QWindowsNativeFileDialogBase::selectFile(const QString &fileName) const
+     // Hack to prevent CLSIDs from being set as file name due to
+     // QFileDialogPrivate::initialSelection() being QString-based.
+     if (!isClsid(fileName))
+-        m_fileDialog->SetFileName((wchar_t*)fileName.utf16());
++    // Patch: Fix handle of full fileName.
++    {
++        QString file = QDir::toNativeSeparators(fileName);
++        int lastBackSlash = file.lastIndexOf(QChar::fromLatin1('\\'));
++        if (lastBackSlash >= 0)
++            file = file.mid(lastBackSlash + 1);
++        m_fileDialog->SetFileName((wchar_t*)file.utf16());;
++    }
+ }
+ 
+ // Return the index of the selected filter, accounting for QFileDialog
+@@ -1449,7 +1456,8 @@ static QString createTemporaryItemCopy(QWindowsShellItem &qItem, QString *errorM
+ static QUrl itemToDialogUrl(QWindowsShellItem &qItem, QString *errorMessage)
+ {
+     QUrl url = qItem.url();
+-    if (url.isLocalFile() || url.scheme().startsWith(u"http"))
++    // Patch: Make loaded 'http' resources copy.
++    if (url.isLocalFile()/*|| url.scheme().startsWith(u"http")*/)
+         return url;
+     const QString path = qItem.path();
+     if (path.isEmpty() && !qItem.isDir() && qItem.canStream()) {

--- a/qtbase_6_2_0/0008-fix-launching-mail-program-on-windows.patch
+++ b/qtbase_6_2_0/0008-fix-launching-mail-program-on-windows.patch
@@ -1,0 +1,15 @@
+diff --git a/src/plugins/platforms/windows/qwindowsservices.cpp b/src/plugins/platforms/windows/qwindowsservices.cpp
+index 9504513a5e..811f3d62bd 100644
+--- a/src/plugins/platforms/windows/qwindowsservices.cpp
++++ b/src/plugins/platforms/windows/qwindowsservices.cpp
+@@ -125,6 +125,10 @@ static inline bool launchMail(const QUrl &url)
+             command.prepend(doubleQuote);
+         }
+     }
++
++    // Patch: Fix mail launch if no param is expected in this command.
++    if (command.indexOf(QStringLiteral("%1")) < 0) return false;
++
+     // Pass the url as the parameter. Should use QProcess::startDetached(),
+     // but that cannot handle a Windows command line [yet].
+     command.replace(QLatin1String("%1"), url.toString(QUrl::FullyEncoded));

--- a/qtbase_6_2_0/0009-fix-gtk-file-dialog-ubuntu-1404.patch
+++ b/qtbase_6_2_0/0009-fix-gtk-file-dialog-ubuntu-1404.patch
@@ -1,0 +1,22 @@
+diff --git a/src/plugins/platformthemes/gtk3/qgtk3theme.cpp b/src/plugins/platformthemes/gtk3/qgtk3theme.cpp
+index 077955eb4e..5c8a3dddf7 100644
+--- a/src/plugins/platformthemes/gtk3/qgtk3theme.cpp
++++ b/src/plugins/platformthemes/gtk3/qgtk3theme.cpp
+@@ -153,7 +153,7 @@ bool QGtk3Theme::usePlatformNativeDialog(DialogType type) const
+     case ColorDialog:
+         return true;
+     case FileDialog:
+-        return useNativeFileDialog();
++        return true;
+     case FontDialog:
+         return true;
+     default:
+@@ -167,8 +167,6 @@ QPlatformDialogHelper *QGtk3Theme::createPlatformDialogHelper(DialogType type) c
+     case ColorDialog:
+         return new QGtk3ColorDialogHelper;
+     case FileDialog:
+-        if (!useNativeFileDialog())
+-            return nullptr;
+         return new QGtk3FileDialogHelper;
+     case FontDialog:
+         return new QGtk3FontDialogHelper;

--- a/qtbase_6_2_0/0010-add-preview-support-to-gtk-file-dialog.patch
+++ b/qtbase_6_2_0/0010-add-preview-support-to-gtk-file-dialog.patch
@@ -1,0 +1,100 @@
+diff --git a/src/plugins/platformthemes/gtk3/qgtk3dialoghelpers.cpp b/src/plugins/platformthemes/gtk3/qgtk3dialoghelpers.cpp
+index 65564b59a1..63c0d6a363 100644
+--- a/src/plugins/platformthemes/gtk3/qgtk3dialoghelpers.cpp
++++ b/src/plugins/platformthemes/gtk3/qgtk3dialoghelpers.cpp
+@@ -45,6 +45,7 @@
+ #include <qcolor.h>
+ #include <qdebug.h>
+ #include <qfont.h>
++#include <qfileinfo.h>
+ 
+ #include <private/qguiapplication_p.h>
+ #include <qpa/qplatformfontdatabase.h>
+@@ -55,6 +56,14 @@
+ #include <gdk/gdkx.h>
+ #include <pango/pango.h>
+ 
++// The size of the preview we display for selected image files. We set height
++// larger than width because generally there is more free space vertically
++// than horiztonally (setting the preview image will alway expand the width of
++// the dialog, but usually not the height). The image's aspect ratio will always
++// be preserved.
++#define PREVIEW_WIDTH 256
++#define PREVIEW_HEIGHT 512
++
+ QT_BEGIN_NAMESPACE
+ 
+ class QGtk3Dialog : public QWindow
+@@ -250,6 +259,10 @@ QGtk3FileDialogHelper::QGtk3FileDialogHelper()
+     g_signal_connect(GTK_FILE_CHOOSER(d->gtkDialog()), "selection-changed", G_CALLBACK(onSelectionChanged), this);
+     g_signal_connect_swapped(GTK_FILE_CHOOSER(d->gtkDialog()), "current-folder-changed", G_CALLBACK(onCurrentFolderChanged), this);
+     g_signal_connect_swapped(GTK_FILE_CHOOSER(d->gtkDialog()), "notify::filter", G_CALLBACK(onFilterChanged), this);
++
++    previewWidget = gtk_image_new();
++    g_signal_connect(G_OBJECT(d->gtkDialog()), "update-preview", G_CALLBACK(onUpdatePreview), this);
++    gtk_file_chooser_set_preview_widget(GTK_FILE_CHOOSER(d->gtkDialog()), previewWidget);
+ }
+ 
+ QGtk3FileDialogHelper::~QGtk3FileDialogHelper()
+@@ -390,6 +403,33 @@ void QGtk3FileDialogHelper::onFilterChanged(QGtk3FileDialogHelper *dialog)
+     emit dialog->filterSelected(dialog->selectedNameFilter());
+ }
+ 
++void QGtk3FileDialogHelper::onUpdatePreview(GtkDialog *gtkDialog, QGtk3FileDialogHelper *helper)
++{
++    gchar *filename = gtk_file_chooser_get_preview_filename(GTK_FILE_CHOOSER(gtkDialog));
++    if (!filename) {
++        gtk_file_chooser_set_preview_widget_active(GTK_FILE_CHOOSER(gtkDialog), false);
++        return;
++    }
++
++    // Don't attempt to open anything which isn't a regular file. If a named pipe,
++    // this may hang.
++    QFileInfo fileinfo(filename);
++    if (!fileinfo.exists() || !fileinfo.isFile()) {
++        g_free(filename);
++        gtk_file_chooser_set_preview_widget_active(GTK_FILE_CHOOSER(gtkDialog), false);
++        return;
++    }
++
++    // This will preserve the image's aspect ratio.
++    GdkPixbuf *pixbuf = gdk_pixbuf_new_from_file_at_size(filename, PREVIEW_WIDTH, PREVIEW_HEIGHT, 0);
++    g_free(filename);
++    if (pixbuf) {
++        gtk_image_set_from_pixbuf(GTK_IMAGE(helper->previewWidget), pixbuf);
++        g_object_unref(pixbuf);
++    }
++    gtk_file_chooser_set_preview_widget_active(GTK_FILE_CHOOSER(gtkDialog), pixbuf ? true : false);
++}
++
+ static GtkFileChooserAction gtkFileChooserAction(const QSharedPointer<QFileDialogOptions> &options)
+ {
+     switch (options->fileMode()) {
+diff --git a/src/plugins/platformthemes/gtk3/qgtk3dialoghelpers.h b/src/plugins/platformthemes/gtk3/qgtk3dialoghelpers.h
+index e78a7fc6d1..1a055ac055 100644
+--- a/src/plugins/platformthemes/gtk3/qgtk3dialoghelpers.h
++++ b/src/plugins/platformthemes/gtk3/qgtk3dialoghelpers.h
+@@ -47,6 +47,7 @@
+ #include <QtCore/qstring.h>
+ #include <qpa/qplatformdialoghelper.h>
+ 
++typedef struct _GtkWidget GtkWidget;
+ typedef struct _GtkDialog GtkDialog;
+ typedef struct _GtkFileFilter GtkFileFilter;
+ 
+@@ -108,6 +109,7 @@ private:
+     static void onSelectionChanged(GtkDialog *dialog, QGtk3FileDialogHelper *helper);
+     static void onCurrentFolderChanged(QGtk3FileDialogHelper *helper);
+     static void onFilterChanged(QGtk3FileDialogHelper *helper);
++    static void onUpdatePreview(GtkDialog *dialog, QGtk3FileDialogHelper *helper);
+     void applyOptions();
+     void setNameFilters(const QStringList &filters);
+     void selectFileInternal(const QUrl &filename);
+@@ -118,6 +120,7 @@ private:
+     QHash<QString, GtkFileFilter*> _filters;
+     QHash<GtkFileFilter*, QString> _filterNames;
+     QScopedPointer<QGtk3Dialog> d;
++    GtkWidget *previewWidget;
+ };
+ 
+ class QGtk3FontDialogHelper : public QPlatformFontDialogHelper

--- a/qtbase_6_2_0/0011-save-dirtyopaquechildren.patch
+++ b/qtbase_6_2_0/0011-save-dirtyopaquechildren.patch
@@ -1,0 +1,43 @@
+diff --git a/src/widgets/kernel/qwidget.cpp b/src/widgets/kernel/qwidget.cpp
+index bf339ca5c5..0981572bd9 100644
+--- a/src/widgets/kernel/qwidget.cpp
++++ b/src/widgets/kernel/qwidget.cpp
+@@ -5161,6 +5161,17 @@ void QWidget::render(QPainter *painter, const QPoint &targetOffset,
+         return; // Fully transparent.
+ 
+     Q_D(QWidget);
++
++    // Patch: save and restore dirtyOpaqueChildren field.
++    //
++    // Just like in QWidget::grab() this field should be restored
++    // after the d->render() call, because it will be set to 1 and
++    // opaqueChildren field will be filled with empty region in
++    // case the widget is hidden (because all the opaque children
++    // will be skipped in isVisible() check).
++    //
++    const bool oldDirtyOpaqueChildren = d->dirtyOpaqueChildren;
++
+     const bool inRenderWithPainter = d->extra && d->extra->inRenderWithPainter;
+     const QRegion toBePainted = !inRenderWithPainter ? d->prepareToRender(sourceRegion, renderFlags)
+                                                      : sourceRegion;
+@@ -5182,6 +5193,10 @@ void QWidget::render(QPainter *painter, const QPoint &targetOffset,
+     if (!inRenderWithPainter && (opacity < 1.0 || (target->devType() == QInternal::Printer))) {
+         d->render_helper(painter, targetOffset, toBePainted, renderFlags);
+         d->extra->inRenderWithPainter = inRenderWithPainter;
++
++        // Patch: save and restore dirtyOpaqueChildren field.
++        d->dirtyOpaqueChildren = oldDirtyOpaqueChildren;
++
+         return;
+     }
+ 
+@@ -5214,6 +5229,9 @@ void QWidget::render(QPainter *painter, const QPoint &targetOffset,
+     d->setSharedPainter(oldPainter);
+ 
+     d->extra->inRenderWithPainter = inRenderWithPainter;
++
++    // Patch: save and restore dirtyOpaqueChildren field.
++    d->dirtyOpaqueChildren = oldDirtyOpaqueChildren;
+ }
+ 
+ static void sendResizeEvents(QWidget *target)

--- a/qtbase_6_2_0/0012-count-scrollbar-sizehint-only-when-needed.patch
+++ b/qtbase_6_2_0/0012-count-scrollbar-sizehint-only-when-needed.patch
@@ -1,0 +1,23 @@
+diff --git a/src/widgets/widgets/qabstractscrollarea.cpp b/src/widgets/widgets/qabstractscrollarea.cpp
+index 720a9f908a..e7b4d3a068 100644
+--- a/src/widgets/widgets/qabstractscrollarea.cpp
++++ b/src/widgets/widgets/qabstractscrollarea.cpp
+@@ -564,15 +564,14 @@ scrolling range.
+ QSize QAbstractScrollArea::maximumViewportSize() const
+ {
+     Q_D(const QAbstractScrollArea);
+-    int hsbExt = d->hbar->sizeHint().height();
+-    int vsbExt = d->vbar->sizeHint().width();
+ 
+     int f = 2 * d->frameWidth;
+     QSize max = size() - QSize(f + d->left + d->right, f + d->top + d->bottom);
++    // Patch: Count the sizeHint of the bar only if it is displayed.
+     if (d->vbarpolicy == Qt::ScrollBarAlwaysOn)
+-        max.rwidth() -= vsbExt;
++        max.rwidth() -= d->vbar->sizeHint().width();
+     if (d->hbarpolicy == Qt::ScrollBarAlwaysOn)
+-        max.rheight() -= hsbExt;
++        max.rheight() -= d->hbar->sizeHint().height();
+     return max;
+ }
+ 

--- a/qtbase_6_2_0/0013-fix-titlebar-contextmenu-on-windows.patch
+++ b/qtbase_6_2_0/0013-fix-titlebar-contextmenu-on-windows.patch
@@ -1,0 +1,12 @@
+diff --git a/src/plugins/platforms/windows/qwindowscontext.cpp b/src/plugins/platforms/windows/qwindowscontext.cpp
+index 38b9823d6b..eaea51d001 100644
+--- a/src/plugins/platforms/windows/qwindowscontext.cpp
++++ b/src/plugins/platforms/windows/qwindowscontext.cpp
+@@ -1014,7 +1014,6 @@ static inline bool isInputMessage(UINT m)
+     case WM_NCMOUSELEAVE:
+     case WM_SIZING:
+     case WM_MOVING:
+-    case WM_SYSCOMMAND:
+     case WM_COMMAND:
+     case WM_DWMNCRENDERINGCHANGED:
+     case WM_PAINT:

--- a/qtbase_6_2_0/0014-old-freetype-compatibility.patch
+++ b/qtbase_6_2_0/0014-old-freetype-compatibility.patch
@@ -1,0 +1,68 @@
+diff --git a/src/gui/CMakeLists.txt b/src/gui/CMakeLists.txt
+index 905afd4038..0e929b58e0 100644
+--- a/src/gui/CMakeLists.txt
++++ b/src/gui/CMakeLists.txt
+@@ -843,7 +843,7 @@ qt_internal_extend_target(Gui CONDITION QT_FEATURE_egl AND NOT QT_FEATURE_egl_x1
+         QT_EGL_NO_X11
+ )
+ 
+-qt_internal_extend_target(Gui CONDITION QT_FEATURE_dlopen AND QT_FEATURE_egl
++qt_internal_extend_target(Gui CONDITION QT_FEATURE_dlopen AND (QT_FEATURE_egl OR QT_FEATURE_system_freetype)
+     LIBRARIES
+         ${CMAKE_DL_LIBS}
+ )
+diff --git a/src/gui/text/freetype/qfontengine_ft.cpp b/src/gui/text/freetype/qfontengine_ft.cpp
+index 12ba46b7ed..8dc43f3113 100644
+--- a/src/gui/text/freetype/qfontengine_ft.cpp
++++ b/src/gui/text/freetype/qfontengine_ft.cpp
+@@ -59,6 +59,10 @@
+ #include <qmath.h>
+ #include <qendian.h>
+ 
++#if QT_CONFIG(system_freetype) && QT_CONFIG(dlopen)
++#include <dlfcn.h>
++#endif
++
+ #include <ft2build.h>
+ #include FT_FREETYPE_H
+ #include FT_OUTLINE_H
+@@ -92,6 +96,8 @@ QT_BEGIN_NAMESPACE
+ #define TRUNC(x)    ((x) >> 6)
+ #define ROUND(x)    (((x)+32) & -64)
+ 
++const char *(*ptrFT_Get_Font_Format)(FT_Face face) = nullptr;
++
+ static bool ft_getSfntTable(void *user_data, uint tag, uchar *buffer, uint *length)
+ {
+     FT_Face face = (FT_Face)user_data;
+@@ -149,9 +155,18 @@ QtFreetypeData *qt_getFreetypeData()
+     if (!freetypeData->library) {
+         FT_Init_FreeType(&freetypeData->library);
+ #if defined(FT_FONT_FORMATS_H)
+-        // Freetype defaults to disabling stem-darkening on CFF, we re-enable it.
+-        FT_Bool no_darkening = false;
+-        FT_Property_Set(freetypeData->library, "cff", "no-stem-darkening", &no_darkening);
++#if QT_CONFIG(system_freetype) && QT_CONFIG(dlopen)
++        ptrFT_Get_Font_Format = reinterpret_cast<decltype(ptrFT_Get_Font_Format)>(dlsym(
++            RTLD_DEFAULT,
++            "FT_Get_Font_Format"));
++#else
++        ptrFT_Get_Font_Format = FT_Get_Font_Format;
++#endif
++        if (ptrFT_Get_Font_Format) {
++            // Freetype defaults to disabling stem-darkening on CFF, we re-enable it.
++            FT_Bool no_darkening = false;
++            FT_Property_Set(freetypeData->library, "cff", "no-stem-darkening", &no_darkening);
++        }
+ #endif
+     }
+     return freetypeData;
+@@ -807,7 +822,7 @@ bool QFontEngineFT::init(FaceId faceId, bool antialias, GlyphFormat format,
+         }
+     }
+ #if defined(FT_FONT_FORMATS_H)
+-    const char *fmt = FT_Get_Font_Format(face);
++    const char *fmt = ptrFT_Get_Font_Format ? ptrFT_Get_Font_Format(face) : nullptr;
+     if (fmt && qstrncmp(fmt, "CFF", 4) == 0) {
+         FT_Bool no_stem_darkening = true;
+         FT_Error err = FT_Property_Get(qt_getFreetype(), "cff", "no-stem-darkening", &no_stem_darkening);

--- a/qtbase_6_2_0/0015-fix-glitching-emoji-cursor.patch
+++ b/qtbase_6_2_0/0015-fix-glitching-emoji-cursor.patch
@@ -1,0 +1,18 @@
+diff --git a/src/gui/text/qtextlayout.cpp b/src/gui/text/qtextlayout.cpp
+index 70e6043231..39ed12512a 100644
+--- a/src/gui/text/qtextlayout.cpp
++++ b/src/gui/text/qtextlayout.cpp
+@@ -1292,10 +1292,13 @@ void QTextLayout::drawCursor(QPainter *p, const QPointF &pos, int cursorPosition
+     bool rightToLeft = d->isRightToLeft();
+     if (itm >= 0) {
+         const QScriptItem &si = d->layoutData->items.at(itm);
++        // Patch: Use line geometry, otherwise smiles get glitching cursor.
++#if 0
+         if (si.ascent >= 0)
+             base = si.ascent;
+         if (si.descent >= 0)
+             descent = si.descent;
++#endif
+         rightToLeft = si.analysis.bidiLevel % 2;
+     }
+     qreal y = position.y() + (sl.y + sl.base() + sl.descent - base - descent).toReal();

--- a/qtbase_6_2_0/0016-nice-osx-tray-icon.patch
+++ b/qtbase_6_2_0/0016-nice-osx-tray-icon.patch
@@ -1,0 +1,216 @@
+diff --git a/src/plugins/platforms/cocoa/qcocoasystemtrayicon.h b/src/plugins/platforms/cocoa/qcocoasystemtrayicon.h
+index ddc76f6b72..fe72340e20 100644
+--- a/src/plugins/platforms/cocoa/qcocoasystemtrayicon.h
++++ b/src/plugins/platforms/cocoa/qcocoasystemtrayicon.h
+@@ -82,11 +82,14 @@ public:
+     bool supportsMessages() const override;
+ 
+     void statusItemClicked();
++    void updateItemIcon();
+ 
+ private:
+     NSStatusItem *m_statusItem = nullptr;
+     QStatusItemDelegate *m_delegate = nullptr;
+     QCocoaMenu *m_menu = nullptr;
++    QIcon m_icon;
++    bool m_handledOnPress = false;
+ };
+ 
+ QT_END_NAMESPACE
+diff --git a/src/plugins/platforms/cocoa/qcocoasystemtrayicon.mm b/src/plugins/platforms/cocoa/qcocoasystemtrayicon.mm
+index 962d1e34b3..e6b1344b60 100644
+--- a/src/plugins/platforms/cocoa/qcocoasystemtrayicon.mm
++++ b/src/plugins/platforms/cocoa/qcocoasystemtrayicon.mm
+@@ -111,6 +111,8 @@ void QCocoaSystemTrayIcon::cleanup()
+     if (center.delegate == m_delegate)
+         center.delegate = nil;
+ 
++    [m_statusItem removeObserver:m_delegate forKeyPath:@"button.effectiveAppearance"];
++
+     [NSStatusBar.systemStatusBar removeStatusItem:m_statusItem];
+     [m_statusItem release];
+     m_statusItem = nil;
+@@ -143,15 +145,26 @@ static QList<QSize> sortByHeight(const QList<QSize> &sizes)
+ }
+ 
+ void QCocoaSystemTrayIcon::updateIcon(const QIcon &icon)
++{
++    m_icon = icon;
++    updateItemIcon();
++}
++
++void QCocoaSystemTrayIcon::updateItemIcon()
+ {
+     if (!m_statusItem)
+         return;
+ 
++    NSAppearance *appearance = m_statusItem.button.effectiveAppearance;
++    NSString *appearanceName = (NSString*)(appearance.name);
++    const auto darkMode = [[appearanceName lowercaseString] containsString:@"dark"];
++    const auto state = darkMode ? QIcon::On : QIcon::Off;
++
+     // The recommended maximum title bar icon height is 18 points
+     // (device independent pixels). The menu height on past and
+     // current OS X versions is 22 points. Provide some future-proofing
+     // by deriving the icon height from the menu height.
+-    const int padding = 4;
++    const int padding = 0;
+     const int menuHeight = NSStatusBar.systemStatusBar.thickness;
+     const int maxImageHeight = menuHeight - padding;
+ 
+@@ -161,54 +174,60 @@ void QCocoaSystemTrayIcon::updateIcon(const QIcon &icon)
+     // devicePixelRatio for the "best" screen on the system.
+     qreal devicePixelRatio = qApp->devicePixelRatio();
+     const int maxPixmapHeight = maxImageHeight * devicePixelRatio;
+-    QSize selectedSize;
+-    for (const QSize& size : sortByHeight(icon.availableSizes())) {
+-        // Select a pixmap based on the height. We want the largest pixmap
+-        // with a height smaller or equal to maxPixmapHeight. The pixmap
+-        // may rectangular; assume it has a reasonable size. If there is
+-        // not suitable pixmap use the smallest one the icon can provide.
+-        if (size.height() <= maxPixmapHeight) {
+-            selectedSize = size;
+-        } else {
+-            if (!selectedSize.isValid())
++
++    const auto imageByMode = [&](QIcon::Mode mode) {
++        QSize selectedSize;
++        for (const QSize& size : sortByHeight(m_icon.availableSizes(mode, state))) {
++            // Select a pixmap based on the height. We want the largest pixmap
++            // with a height smaller or equal to maxPixmapHeight. The pixmap
++            // may rectangular; assume it has a reasonable size. If there is
++            // not suitable pixmap use the smallest one the icon can provide.
++            if (size.height() <= maxPixmapHeight) {
+                 selectedSize = size;
+-            break;
++            } else {
++                if (!selectedSize.isValid())
++                    selectedSize = size;
++                break;
++            }
+         }
+-    }
+ 
+-    // Handle SVG icons, which do not return anything for availableSizes().
+-    if (!selectedSize.isValid())
+-        selectedSize = icon.actualSize(QSize(maxPixmapHeight, maxPixmapHeight));
+-
+-    QPixmap pixmap = icon.pixmap(selectedSize);
+-
+-    // Draw a low-resolution icon if there is not enough pixels for a retina
+-    // icon. This prevents showing a small icon on retina displays.
+-    if (devicePixelRatio > 1.0 && selectedSize.height() < maxPixmapHeight / 2)
+-        devicePixelRatio = 1.0;
+-
+-    // Scale large pixmaps to fit the available menu bar area.
+-    if (pixmap.height() > maxPixmapHeight)
+-        pixmap = pixmap.scaledToHeight(maxPixmapHeight, Qt::SmoothTransformation);
+-
+-    // The icon will be stretched over the full height of the menu bar
+-    // therefore we create a second pixmap which has the full height
+-    QSize fullHeightSize(!pixmap.isNull() ? pixmap.width():
+-                                            menuHeight * devicePixelRatio,
+-                         menuHeight * devicePixelRatio);
+-    QPixmap fullHeightPixmap(fullHeightSize);
+-    fullHeightPixmap.fill(Qt::transparent);
+-    if (!pixmap.isNull()) {
+-        QPainter p(&fullHeightPixmap);
+-        QRect r = pixmap.rect();
+-        r.moveCenter(fullHeightPixmap.rect().center());
+-        p.drawPixmap(r, pixmap);
+-    }
+-    fullHeightPixmap.setDevicePixelRatio(devicePixelRatio);
+-
+-    auto *nsimage = [NSImage imageFromQImage:fullHeightPixmap.toImage()];
+-    [nsimage setTemplate:icon.isMask()];
+-    m_statusItem.button.image = nsimage;
++        // Handle SVG icons, which do not return anything for availableSizes().
++        if (!selectedSize.isValid())
++            selectedSize = m_icon.actualSize(QSize(maxPixmapHeight, maxPixmapHeight), mode, state);
++
++        QPixmap pixmap = m_icon.pixmap(selectedSize, mode, state);
++
++        // Draw a low-resolution icon if there is not enough pixels for a retina
++        // icon. This prevents showing a small icon on retina displays.
++        if (devicePixelRatio > 1.0 && selectedSize.height() < maxPixmapHeight / 2)
++            devicePixelRatio = 1.0;
++
++        // Scale large pixmaps to fit the available menu bar area.
++        if (pixmap.height() > maxPixmapHeight)
++            pixmap = pixmap.scaledToHeight(maxPixmapHeight, Qt::SmoothTransformation);
++
++        // The icon will be stretched over the full height of the menu bar
++        // therefore we create a second pixmap which has the full height
++        // QSize fullHeightSize(!pixmap.isNull() ? pixmap.width():
++        //                                         menuHeight * devicePixelRatio,
++        //                      menuHeight * devicePixelRatio);
++        // QPixmap fullHeightPixmap(fullHeightSize);
++        // fullHeightPixmap.fill(Qt::transparent);
++        // if (!pixmap.isNull()) {
++        //     QPainter p(&fullHeightPixmap);
++        //     QRect r = pixmap.rect();
++        //     r.moveCenter(fullHeightPixmap.rect().center());
++        //     p.drawPixmap(r, pixmap);
++        // }
++        // fullHeightPixmap.setDevicePixelRatio(devicePixelRatio);
++
++        auto *nsimage = [NSImage imageFromQImage:pixmap.toImage()];
++        [nsimage setTemplate:m_icon.isMask()];
++
++        return nsimage;
++    };
++    m_statusItem.button.image = imageByMode(QIcon::Normal);
++    m_statusItem.button.alternateImage = imageByMode(QIcon::Active);
+     m_statusItem.button.imageScaling = NSImageScaleProportionallyDown;
+ }
+ 
+@@ -266,6 +285,18 @@ void QCocoaSystemTrayIcon::statusItemClicked()
+ {
+     auto *mouseEvent = NSApp.currentEvent;
+ 
++	if (mouseEvent.type == NSEventTypeLeftMouseDown) {
++		m_handledOnPress = !m_menu;
++		if (!m_handledOnPress) {
++			return;
++		}
++		[m_statusItem.button highlight:NO];
++	} else if (mouseEvent.type == NSEventTypeLeftMouseUp) {
++		if (m_handledOnPress) {
++			return;
++		}
++	}
++
+     auto activationReason = QPlatformSystemTrayIcon::Unknown;
+ 
+     if (mouseEvent.clickCount == 2) {
+@@ -322,6 +353,14 @@ QT_END_NAMESPACE
+     emit self.platformSystemTray->messageClicked();
+ }
+ 
++// Thanks https://stackoverflow.com/a/64525038
++-(void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context
++{
++    if ([keyPath isEqualToString:@"button.effectiveAppearance"]) {
++        self.platformSystemTray->updateItemIcon();
++    }
++}
++
+ @end
+ 
+ #endif // QT_NO_SYSTEMTRAYICON
+diff --git a/src/widgets/util/qsystemtrayicon_qpa.cpp b/src/widgets/util/qsystemtrayicon_qpa.cpp
+index 9694e0a6b3..401c61bbf9 100644
+--- a/src/widgets/util/qsystemtrayicon_qpa.cpp
++++ b/src/widgets/util/qsystemtrayicon_qpa.cpp
+@@ -98,6 +98,11 @@ void QSystemTrayIconPrivate::updateMenu_sys()
+     if (qpa_sys && menu) {
+         addPlatformMenu(menu);
+         qpa_sys->updateMenu(menu->platformMenu());
++
++    // Patch: Create a rich os x tray icon (pixel-perfect, theme switching).
++    } else if (qpa_sys) {
++        qpa_sys->updateMenu(nullptr);
++
+     }
+ #endif
+ }

--- a/qtbase_6_2_0/0017-fix-crash-in-network-reply-finished.patch
+++ b/qtbase_6_2_0/0017-fix-crash-in-network-reply-finished.patch
@@ -1,0 +1,32 @@
+diff --git a/src/network/access/qnetworkreplyhttpimpl.cpp b/src/network/access/qnetworkreplyhttpimpl.cpp
+index e82184ff95..c17f0aa53b 100644
+--- a/src/network/access/qnetworkreplyhttpimpl.cpp
++++ b/src/network/access/qnetworkreplyhttpimpl.cpp
+@@ -1994,6 +1994,9 @@ void QNetworkReplyHttpImplPrivate::_q_finished()
+ void QNetworkReplyHttpImplPrivate::finished()
+ {
+     Q_Q(QNetworkReplyHttpImpl);
++
++    QPointer<QNetworkReplyHttpImpl> guard = q;
++
+     if (transferTimeout)
+       transferTimeout->stop();
+     if (state == Finished || state == Aborted)
+@@ -2001,6 +2004,8 @@ void QNetworkReplyHttpImplPrivate::finished()
+ 
+     QVariant totalSize = cookedHeaders.value(QNetworkRequest::ContentLengthHeader);
+ 
++    if (!guard) return;
++
+     // if we don't know the total size of or we received everything save the cache
+     if (totalSize.isNull() || totalSize == -1 || bytesDownloaded == totalSize)
+         completeCacheSave();
+@@ -2010,6 +2015,8 @@ void QNetworkReplyHttpImplPrivate::finished()
+     if (isHttpRedirectResponse() && errorCode == QNetworkReply::NoError)
+         return;
+ 
++    if (!guard) return;
++
+     state = Finished;
+     q->setFinished(true);
+ 

--- a/qtbase_6_2_0/0018-workaround-crash-text-engine.patch
+++ b/qtbase_6_2_0/0018-workaround-crash-text-engine.patch
@@ -1,0 +1,119 @@
+diff --git a/src/gui/text/qtextengine.cpp b/src/gui/text/qtextengine.cpp
+index 74967aeac9..c0d283fb22 100644
+--- a/src/gui/text/qtextengine.cpp
++++ b/src/gui/text/qtextengine.cpp
+@@ -1395,6 +1395,52 @@ static void applyVisibilityRules(ushort ucs, QGlyphLayout *glyphs, uint glyphPos
+     }
+ }
+ 
++// Attempt to work around assertion violation in harfbuzz text shaping.
++// See https://bugreports.qt.io/browse/QTBUG-89155.
++// See 'hb_bool_t is_default_ignorable' in hb-unicode-private.hh
++static inline bool IsDefaultIgnorable(uint ch) {
++    const auto plane = ch >> 16;
++    const auto inrange = [](uint ch, uint from, uint till) {
++        return uint(ch - from) <= uint(till - from);
++    };
++    if (plane == 0) {
++        /* BMP */
++        const auto page = ch >> 8;
++        switch (page) {
++        case 0x00:
++            return (ch == 0x00ADu);
++        case 0x03:
++            return (ch == 0x034Fu);
++        case 0x06:
++            return (ch == 0x061Cu);
++        case 0x17:
++            return inrange(ch, 0x17B4u, 0x17B5u);
++        case 0x18:
++            return inrange(ch, 0x180Bu, 0x180Eu);
++        case 0x20:
++            return inrange(ch, 0x200Bu, 0x200Fu)
++                    || inrange(ch, 0x202Au, 0x202Eu)
++                    || inrange(ch, 0x2060u, 0x206Fu);
++        case 0xFE:
++            return inrange(ch, 0xFE00u, 0xFE0Fu) || ch == 0xFEFFu;
++        case 0xFF:
++            return inrange(ch, 0xFFF0u, 0xFFF8u);
++        default:
++            return false;
++        }
++    } else {
++        /* Other planes */
++        switch (plane) {
++        case 0x01:
++            return inrange(ch, 0x1D173u, 0x1D17Au);
++        case 0x0E:
++            return inrange(ch, 0xE0000u, 0xE0FFFu);
++        default:
++            return false;
++        }
++    }
++}
++
+ void QTextEngine::shapeText(int item) const
+ {
+     Q_ASSERT(item < layoutData->items.size());
+@@ -1516,6 +1562,61 @@ void QTextEngine::shapeText(int item) const
+         itemBoundaries.append(0);
+     }
+ 
++    // Attempt to work around assertion violation in harfbuzz text shaping.
++    // See https://bugreports.qt.io/browse/QTBUG-89155.
++    for (int k = 0; k < itemBoundaries.size(); k += 3) {
++        const uint item_pos = itemBoundaries[k];
++        const uint item_length =
++            (k + 4 < itemBoundaries.size() ? itemBoundaries[k + 3] : itemLength) - item_pos;
++
++        // Check if the full string part contains only default ignorables.
++        auto ch = reinterpret_cast<const QChar *>(string) + item_pos;
++        const auto end = ch + item_length;
++        for (; ch != end; ++ch) {
++            uint ucs4 = ch->unicode();
++            if (QChar::isHighSurrogate(ucs4) && ch + 1 != end) {
++                uint low = (ch + 1)->unicode();
++                if (QChar::isLowSurrogate(low)) {
++                    // high part never changes in simple casing
++                    ucs4 = QChar::surrogateToUcs4(ucs4, low);
++                    ++ch;
++                }
++            }
++            if (!IsDefaultIgnorable(ucs4)) {
++                break;
++            }
++        }
++
++        const auto allDefaultIgnorables = (ch == end);
++        if (allDefaultIgnorables) {
++            // Make sure harfbuzz will be able to replace those by spaces.
++            const uint engineIdx = itemBoundaries[k + 2];
++            QFontEngine *actualFontEngine = fontEngine;
++            if (actualFontEngine->type() == QFontEngine::Multi) {
++                actualFontEngine = static_cast<QFontEngineMulti *>(fontEngine)->engine(engineIdx);
++            }
++            if (!actualFontEngine->glyphIndex(' ')) {
++                // This is a font without a glyph for space.
++                // If we try to shape an item, containing only default ignorables, with it,
++                // we will end up in Q_UNREACHABLE below, after Q_UNLIKELY(si.num_glyphs == 0).
++                const auto spaceGlyphIndex = fontEngine->glyphIndex(' ');
++                Q_ASSERT(spaceGlyphIndex != 0);
++                const auto goodEngineIdx = (spaceGlyphIndex >> 24);
++                Q_ASSERT(goodEngineIdx != engineIdx);
++
++                uint glyph_pos = itemBoundaries[k + 1];
++                const uint glyph_till =
++                        (k + 5 < itemBoundaries.size() ? itemBoundaries[k + 4] : nGlyphs);
++
++                for (; glyph_pos < glyph_till; ++glyph_pos) {
++                    initialGlyphs.glyphs[glyph_pos] =
++                            (initialGlyphs.glyphs[glyph_pos] & 0x00FFFFFFU) | (goodEngineIdx << 24);
++                }
++                itemBoundaries[k + 2] = goodEngineIdx;
++            }
++        }
++    }
++
+ #if QT_CONFIG(harfbuzz)
+     if (Q_LIKELY(shapingEnabled && qt_useHarfbuzzNG())) {
+         si.num_glyphs = shapeTextWithHarfbuzzNG(si, string, itemLength, fontEngine, itemBoundaries, kerningEnabled, letterSpacing != 0);

--- a/qtbase_6_2_0/0019-allow-startsystemmoveresize-on-unity.patch
+++ b/qtbase_6_2_0/0019-allow-startsystemmoveresize-on-unity.patch
@@ -1,0 +1,30 @@
+diff --git a/src/plugins/platforms/xcb/qxcbwindow.cpp b/src/plugins/platforms/xcb/qxcbwindow.cpp
+index 9e7e1a5572..b946453d3b 100644
+--- a/src/plugins/platforms/xcb/qxcbwindow.cpp
++++ b/src/plugins/platforms/xcb/qxcbwindow.cpp
+@@ -2360,22 +2360,11 @@ bool QXcbWindow::startSystemMoveResize(const QPoint &pos, int edges)
+     if (!connection()->wmSupport()->isSupportedByWM(moveResize))
+         return false;
+ 
+-    // ### FIXME QTBUG-53389
+-    bool startedByTouch = connection()->startSystemMoveResizeForTouch(m_window, edges);
+-    if (startedByTouch) {
+-        if (connection()->isUnity()) {
+-            // Unity fails to move/resize via _NET_WM_MOVERESIZE (WM bug?).
+-            connection()->abortSystemMoveResizeForTouch();
+-            return false;
+-        }
+-        // KWin, Openbox, AwesomeWM and Gnome have been tested to work with _NET_WM_MOVERESIZE.
+-    } else { // Started by mouse press.
+-        if (connection()->isUnity())
+-            return false; // _NET_WM_MOVERESIZE on this WM is bouncy (WM bug?).
+-
+-        doStartSystemMoveResize(mapToGlobal(pos), edges);
++    if (connection()->startSystemMoveResizeForTouch(m_window, edges)) {
++        return true;
+     }
+ 
++    doStartSystemMoveResize(mapToGlobal(pos), edges);
+     return true;
+ }
+ 

--- a/qtbase_6_2_0/0020-always-use-xft-font-conf.patch
+++ b/qtbase_6_2_0/0020-always-use-xft-font-conf.patch
@@ -1,0 +1,144 @@
+diff --git a/src/gui/text/unix/qfontconfigdatabase.cpp b/src/gui/text/unix/qfontconfigdatabase.cpp
+index ee9d323747..b79b0b740f 100644
+--- a/src/gui/text/unix/qfontconfigdatabase.cpp
++++ b/src/gui/text/unix/qfontconfigdatabase.cpp
+@@ -48,8 +48,6 @@
+ 
+ #include <qpa/qplatformnativeinterface.h>
+ #include <qpa/qplatformscreen.h>
+-#include <qpa/qplatformintegration.h>
+-#include <qpa/qplatformservices.h>
+ 
+ #include <QtGui/private/qguiapplication_p.h>
+ #include <QtGui/private/qhighdpiscaling_p.h>
+@@ -640,7 +638,15 @@ QFontEngineMulti *QFontconfigDatabase::fontEngineMulti(QFontEngine *fontEngine,
+ }
+ 
+ namespace {
+-QFontEngine::HintStyle defaultHintStyleFromMatch(QFont::HintingPreference hintingPreference, FcPattern *match, bool useXftConf)
++template<typename T>
++inline T fromPlatformNativeResource(int nativeValue)
++{
++    // native resource returns nullptr at fail,
++    // so successful values are returned with + 1
++    return static_cast<T>(nativeValue - 1);
++}
++
++QFontEngine::HintStyle defaultHintStyleFromMatch(QFont::HintingPreference hintingPreference, FcPattern *match)
+ {
+     switch (hintingPreference) {
+     case QFont::PreferNoHinting:
+@@ -656,9 +662,15 @@ QFontEngine::HintStyle defaultHintStyleFromMatch(QFont::HintingPreference hintin
+     if (QHighDpiScaling::isActive())
+         return QFontEngine::HintNone;
+ 
+-    int hint_style = 0;
+-    if (FcPatternGetInteger (match, FC_HINT_STYLE, 0, &hint_style) == FcResultMatch) {
+-        switch (hint_style) {
++    void *hintStyleResource =
++            QGuiApplication::platformNativeInterface()->nativeResourceForScreen("hintstyle",
++                                                                                QGuiApplication::primaryScreen());
++    int hintStyle = int(reinterpret_cast<qintptr>(hintStyleResource));
++    if (hintStyle > 0)
++        return fromPlatformNativeResource<QFontEngine::HintStyle>(hintStyle);
++
++    if (FcPatternGetInteger (match, FC_HINT_STYLE, 0, &hintStyle) == FcResultMatch) {
++        switch (hintStyle) {
+         case FC_HINT_NONE:
+             return QFontEngine::HintNone;
+         case FC_HINT_SLIGHT:
+@@ -673,23 +685,20 @@ QFontEngine::HintStyle defaultHintStyleFromMatch(QFont::HintingPreference hintin
+         }
+     }
+ 
+-    if (useXftConf) {
+-        void *hintStyleResource =
+-                QGuiApplication::platformNativeInterface()->nativeResourceForScreen("hintstyle",
+-                                                                                    QGuiApplication::primaryScreen());
+-        int hintStyle = int(reinterpret_cast<qintptr>(hintStyleResource));
+-        if (hintStyle > 0)
+-            return QFontEngine::HintStyle(hintStyle - 1);
+-    }
+-
+     return QFontEngine::HintFull;
+ }
+ 
+-QFontEngine::SubpixelAntialiasingType subpixelTypeFromMatch(FcPattern *match, bool useXftConf)
++QFontEngine::SubpixelAntialiasingType subpixelTypeFromMatch(FcPattern *match)
+ {
+-    int subpixel = FC_RGBA_UNKNOWN;
+-    if (FcPatternGetInteger(match, FC_RGBA, 0, &subpixel) == FcResultMatch) {
+-        switch (subpixel) {
++    void *subpixelTypeResource =
++            QGuiApplication::platformNativeInterface()->nativeResourceForScreen("subpixeltype",
++                                                                                QGuiApplication::primaryScreen());
++    int subpixelType = int(reinterpret_cast<qintptr>(subpixelTypeResource));
++    if (subpixelType > 0)
++        return fromPlatformNativeResource<QFontEngine::SubpixelAntialiasingType>(subpixelType);
++
++    if (FcPatternGetInteger(match, FC_RGBA, 0, &subpixelType) == FcResultMatch) {
++        switch (subpixelType) {
+         case FC_RGBA_UNKNOWN:
+         case FC_RGBA_NONE:
+             return QFontEngine::Subpixel_None;
+@@ -707,15 +716,6 @@ QFontEngine::SubpixelAntialiasingType subpixelTypeFromMatch(FcPattern *match, bo
+         }
+     }
+ 
+-    if (useXftConf) {
+-        void *subpixelTypeResource =
+-                QGuiApplication::platformNativeInterface()->nativeResourceForScreen("subpixeltype",
+-                                                                                    QGuiApplication::primaryScreen());
+-        int subpixelType = int(reinterpret_cast<qintptr>(subpixelTypeResource));
+-        if (subpixelType > 0)
+-            return QFontEngine::SubpixelAntialiasingType(subpixelType - 1);
+-    }
+-
+     return QFontEngine::Subpixel_None;
+ }
+ } // namespace
+@@ -954,21 +954,15 @@ void QFontconfigDatabase::setupFontEngine(QFontEngineFT *engine, const QFontDef
+     bool antialias = !(fontDef.styleStrategy & QFont::NoAntialias);
+     bool forcedAntialiasSetting = !antialias || QHighDpiScaling::isActive();
+ 
+-    const QPlatformServices *services = QGuiApplicationPrivate::platformIntegration()->services();
+-    bool useXftConf = false;
+-
+-    if (services) {
+-        const QList<QByteArray> desktopEnv = services->desktopEnvironment().split(':');
+-        useXftConf = desktopEnv.contains("GNOME") || desktopEnv.contains("UNITY") || desktopEnv.contains("XFCE");
+-    }
+-
+-    if (useXftConf && !forcedAntialiasSetting) {
++    if (!forcedAntialiasSetting) {
+         void *antialiasResource =
+                 QGuiApplication::platformNativeInterface()->nativeResourceForScreen("antialiasingEnabled",
+                                                                                     QGuiApplication::primaryScreen());
+         int antialiasingEnabled = int(reinterpret_cast<qintptr>(antialiasResource));
+-        if (antialiasingEnabled > 0)
+-            antialias = antialiasingEnabled - 1;
++        if (antialiasingEnabled > 0) {
++            antialias = fromPlatformNativeResource<bool>(antialiasingEnabled);
++            forcedAntialiasSetting = true;
++        }
+     }
+ 
+     QFontEngine::GlyphFormat format;
+@@ -1002,7 +996,7 @@ void QFontconfigDatabase::setupFontEngine(QFontEngineFT *engine, const QFontDef
+ 
+     FcPattern *match = FcFontMatch(nullptr, pattern, &result);
+     if (match) {
+-        engine->setDefaultHintStyle(defaultHintStyleFromMatch((QFont::HintingPreference)fontDef.hintingPreference, match, useXftConf));
++        engine->setDefaultHintStyle(defaultHintStyleFromMatch((QFont::HintingPreference)fontDef.hintingPreference, match));
+ 
+         FcBool fc_autohint;
+         if (FcPatternGetBool(match, FC_AUTOHINT,0, &fc_autohint) == FcResultMatch)
+@@ -1023,7 +1017,7 @@ void QFontconfigDatabase::setupFontEngine(QFontEngineFT *engine, const QFontDef
+         if (antialias) {
+             QFontEngine::SubpixelAntialiasingType subpixelType = QFontEngine::Subpixel_None;
+             if (!(fontDef.styleStrategy & QFont::NoSubpixelAntialias))
+-                subpixelType = subpixelTypeFromMatch(match, useXftConf);
++                subpixelType = subpixelTypeFromMatch(match);
+             engine->subpixelType = subpixelType;
+ 
+             format = (subpixelType == QFontEngine::Subpixel_None)

--- a/qtbase_6_2_0/0021-catch-cocoa-dock-menu.patch
+++ b/qtbase_6_2_0/0021-catch-cocoa-dock-menu.patch
@@ -1,0 +1,18 @@
+diff --git a/src/plugins/platforms/cocoa/qcocoaapplicationdelegate.mm b/src/plugins/platforms/cocoa/qcocoaapplicationdelegate.mm
+index e8d789275c..9981588219 100644
+--- a/src/plugins/platforms/cocoa/qcocoaapplicationdelegate.mm
++++ b/src/plugins/platforms/cocoa/qcocoaapplicationdelegate.mm
+@@ -138,7 +138,12 @@ QT_USE_NAMESPACE
+ 
+ - (NSMenu *)applicationDockMenu:(NSApplication *)sender
+ {
+-    Q_UNUSED(sender);
++    // Patch: We need to catch that event in delegate.
++    if (reflectionDelegate
++        && [reflectionDelegate respondsToSelector:@selector(applicationDockMenu:)]) {
++        return [reflectionDelegate applicationDockMenu:sender];
++    }
++
+     // Manually invoke the delegate's -menuWillOpen: method.
+     // See QTBUG-39604 (and its fix) for details.
+     [self.dockMenu.delegate menuWillOpen:self.dockMenu];

--- a/qtbase_6_2_0/0022-fix-crash-in-QXcbBasicConnection-internAtom.patch
+++ b/qtbase_6_2_0/0022-fix-crash-in-QXcbBasicConnection-internAtom.patch
@@ -1,0 +1,17 @@
+diff --git a/src/plugins/platforms/xcb/qxcbconnection_basic.cpp b/src/plugins/platforms/xcb/qxcbconnection_basic.cpp
+index 18dee89adb..e7927d9508 100644
+--- a/src/plugins/platforms/xcb/qxcbconnection_basic.cpp
++++ b/src/plugins/platforms/xcb/qxcbconnection_basic.cpp
+@@ -179,7 +179,11 @@ xcb_atom_t QXcbBasicConnection::internAtom(const char *name)
+     if (!name || *name == 0)
+         return XCB_NONE;
+ 
+-    return Q_XCB_REPLY(xcb_intern_atom, m_xcbConnection, false, strlen(name), name)->atom;
++    auto reply = Q_XCB_REPLY(xcb_intern_atom, m_xcbConnection, false, strlen(name), name);
++    if (reply)
++        return reply->atom;
++
++    return XCB_NONE;
+ }
+ 
+ QByteArray QXcbBasicConnection::atomName(xcb_atom_t atom)

--- a/qtbase_6_2_0/0023-fix-open-macos-window-ghost-focused-after-popup.patch
+++ b/qtbase_6_2_0/0023-fix-open-macos-window-ghost-focused-after-popup.patch
@@ -1,0 +1,24 @@
+diff --git a/src/widgets/kernel/qapplication.cpp b/src/widgets/kernel/qapplication.cpp
+index de450923ff..f900aa6903 100644
+--- a/src/widgets/kernel/qapplication.cpp
++++ b/src/widgets/kernel/qapplication.cpp
+@@ -2712,6 +2712,19 @@ bool QApplication::notify(QObject *receiver, QEvent *e)
+         // by pressing ALT-TAB on Windows, which is not receive as key event.
+         // triggers when the screen rotates.)
+         closeAllPopups();
++
++        // In case of macOS popup menu activating another app,
++        // we first get windowDidResignKey() for the main window,
++        // that clears focusWindow(), but notifyActiveWindowChange()
++        // is cancelled by inPopupMode() check (popup is still alive).
++        // After that all popups are destroyed here and the window
++        // gets back its (non real) active / focused state.
++        // We try to workaround it here by checking for inconsistency
++        // between focusWindow() and activeWindow() properties.
++        if (!focusWindow() && activeWindow()) {
++            d->notifyActiveWindowChange(activeWindow()->windowHandle());
++        }
++
+         break;
+     case QEvent::Wheel: // User input and window activation makes tooltips sleep
+     case QEvent::ActivationChange:

--- a/qtbase_6_2_0/0024-fix-race-in-windows-timers.patch
+++ b/qtbase_6_2_0/0024-fix-race-in-windows-timers.patch
@@ -1,0 +1,139 @@
+diff --git a/src/corelib/kernel/qeventdispatcher_win.cpp b/src/corelib/kernel/qeventdispatcher_win.cpp
+index 97e3cbdb04..d5dc2cbe3d 100644
+--- a/src/corelib/kernel/qeventdispatcher_win.cpp
++++ b/src/corelib/kernel/qeventdispatcher_win.cpp
+@@ -114,7 +114,17 @@ void WINAPI QT_WIN_CALLBACK qt_fast_timer_proc(uint timerId, uint /*reserved*/,
+         return;
+     auto t = reinterpret_cast<WinTimerInfo*>(user);
+     Q_ASSERT(t);
+-    QCoreApplication::postEvent(t->dispatcher, new QTimerEvent(t->timerId));
++    QMutexLocker lock(&t->fastTimerMutex);
++    if (t->timerId != -1) {
++        QCoreApplication::postEvent(t->dispatcher, new QTimerEvent(t->timerId));
++        return;
++    }
++    Q_ASSERT(!t->inTimerEvent);
++    Q_ASSERT(t->fastTimerId != 0);
++    timeKillEvent(t->fastTimerId);
++    lock.unlock();
++
++    delete t;
+ }
+ 
+ LRESULT QT_WIN_CALLBACK qt_internal_proc(HWND hwnd, UINT message, WPARAM wp, LPARAM lp)
+@@ -358,12 +368,12 @@ void QEventDispatcherWin32Private::registerTimer(WinTimerInfo *t)
+         // optimization for single-shot-zero-timer
+         QCoreApplication::postEvent(q, new QZeroTimerEvent(t->timerId));
+         ok = true;
+-    } else if (interval < 20u || t->timerType == Qt::PreciseTimer) {
++    } else if (interval < 20u || (interval < 1000u && t->timerType == Qt::PreciseTimer)) {
+         // 3/2016: Although MSDN states timeSetEvent() is deprecated, the function
+         // is still deemed to be the most reliable precision timer.
+         t->fastTimerId = timeSetEvent(interval, 1, qt_fast_timer_proc, DWORD_PTR(t),
+                                       TIME_CALLBACK_FUNCTION | TIME_PERIODIC | TIME_KILL_SYNCHRONOUS);
+-        ok = t->fastTimerId;
++        ok = (t->fastTimerId != 0);
+     }
+ 
+     if (!ok) {
+@@ -377,16 +387,34 @@ void QEventDispatcherWin32Private::registerTimer(WinTimerInfo *t)
+ 
+ void QEventDispatcherWin32Private::unregisterTimer(WinTimerInfo *t)
+ {
++    const auto tTimerId = t->timerId;
++    const auto tDispatcher = t->dispatcher;
++    const auto tUseFastTimer = (t->fastTimerId != 0);
++    const auto tDelete = (!tUseFastTimer && !t->inTimerEvent);
+     if (t->interval == 0) {
+-        QCoreApplicationPrivate::removePostedTimerEvent(t->dispatcher, t->timerId);
+-    } else if (t->fastTimerId != 0) {
+-        timeKillEvent(t->fastTimerId);
+-        QCoreApplicationPrivate::removePostedTimerEvent(t->dispatcher, t->timerId);
++        QCoreApplicationPrivate::removePostedTimerEvent(tDispatcher, tTimerId);
++    } else if (tUseFastTimer) {
++        // 't' will be deleted in the next qt_fast_timer_proc.
++        // timeKillEvent(t->fastTimerId);
+     } else {
+-        KillTimer(internalHwnd, t->timerId);
++        KillTimer(internalHwnd, tTimerId);
++    }
++    if (tUseFastTimer && !t->inTimerEvent) {
++        // sendTimerEvent locks the mutex in case of t->inTimerEvent.
++        t->fastTimerMutex.lock();
+     }
++    // Upon fastTimerMutex unlock qt_fast_timer_proc may delete 't'.
+     t->timerId = -1;
+-    if (!t->inTimerEvent)
++    if (tUseFastTimer) {
++        if (!t->inTimerEvent) {
++            // sendTimerEvent unlocks the mutex in case of t->inTimerEvent.
++            // Right after that line qt_fast_timer_proc may delete 't'.
++            t->fastTimerMutex.unlock();
++        }
++        QCoreApplicationPrivate::removePostedTimerEvent(tDispatcher, tTimerId);
++    }
++
++    if (tDelete)
+         delete t;
+ }
+ 
+@@ -401,14 +429,27 @@ void QEventDispatcherWin32Private::sendTimerEvent(int timerId)
+         calculateNextTimeout(t, qt_msectime());
+ 
+         QTimerEvent e(t->timerId);
++
++        const auto tUseFastTimer = (t->fastTimerId != 0);
++        if (tUseFastTimer) {
++            // sendEvent below may unregisterTimer,
++            // qt_fast_timer_proc should not delete 't' just yet.
++            t->fastTimerMutex.lock();
++        }
++
+         QCoreApplication::sendEvent(t->obj, &e);
+ 
+         // timer could have been removed
+-        if (t->timerId == -1) {
++        if (t->timerId == -1 && !tUseFastTimer) {
+             delete t;
+         } else {
+             t->inTimerEvent = false;
+         }
++
++        if (tUseFastTimer) {
++            // Right after that line qt_fast_timer_proc may delete 't'.
++            t->fastTimerMutex.unlock();
++        }
+     }
+ }
+ 
+@@ -868,7 +909,9 @@ bool QEventDispatcherWin32::event(QEvent *e)
+ 
+             // timer could have been removed
+             if (t->timerId == -1) {
+-                delete t;
++                if (t->fastTimerId == 0) {
++                    delete t;
++                }
+             } else {
+                 if (t->interval == 0 && t->inTimerEvent) {
+                     // post the next zero timer event as long as the timer was not restarted
+diff --git a/src/corelib/kernel/qeventdispatcher_win_p.h b/src/corelib/kernel/qeventdispatcher_win_p.h
+index 49a6d3ebbc..beefde6cd6 100644
+--- a/src/corelib/kernel/qeventdispatcher_win_p.h
++++ b/src/corelib/kernel/qeventdispatcher_win_p.h
+@@ -55,6 +55,7 @@
+ #include "QtCore/qt_windows.h"
+ #include "QtCore/qhash.h"
+ #include "QtCore/qatomic.h"
++#include "QtCore/qmutex.h"
+ 
+ #include "qabstracteventdispatcher_p.h"
+ 
+@@ -130,6 +131,7 @@ struct WinTimerInfo {                           // internal timer info
+     QObject *obj;                               // - object to receive events
+     bool inTimerEvent;
+     UINT fastTimerId;
++    QMutex fastTimerMutex;
+ };
+ 
+ class QZeroTimerEvent : public QTimerEvent

--- a/qtbase_6_2_0/0025-handle-amd_switchable-in-gpu-bugs-list.patch
+++ b/qtbase_6_2_0/0025-handle-amd_switchable-in-gpu-bugs-list.patch
@@ -1,0 +1,120 @@
+diff --git a/src/gui/opengl/qopengl.cpp b/src/gui/opengl/qopengl.cpp
+index 3066b83282..cc5947b4f6 100644
+--- a/src/gui/opengl/qopengl.cpp
++++ b/src/gui/opengl/qopengl.cpp
+@@ -389,6 +389,12 @@ static bool matches(const QJsonObject &object,
+         }
+     }
+ 
++    if (object.value(QLatin1String("multi_gpu_style")).toString() == QLatin1String("amd_switchable")) {
++        if (!gpu.amdSwitchable) {
++            return false;
++        }
++    }
++
+     return true;
+ }
+ 
+diff --git a/src/gui/opengl/qopengl_p.h b/src/gui/opengl/qopengl_p.h
+index 07fd159ba8..1490a7e2d6 100644
+--- a/src/gui/opengl/qopengl_p.h
++++ b/src/gui/opengl/qopengl_p.h
+@@ -95,6 +95,8 @@ public:
+         QByteArray driverDescription;
+         QByteArray glVendor;
+ 
++        bool amdSwitchable = false;
++
+         static Gpu fromDevice(uint vendorId, uint deviceId, QVersionNumber driverVersion, const QByteArray &driverDescription) {
+             Gpu gpu;
+             gpu.vendorId = vendorId;
+diff --git a/src/plugins/platforms/windows/qwindowsopengltester.cpp b/src/plugins/platforms/windows/qwindowsopengltester.cpp
+index 0b1af47a65..b75c34be62 100644
+--- a/src/plugins/platforms/windows/qwindowsopengltester.cpp
++++ b/src/plugins/platforms/windows/qwindowsopengltester.cpp
+@@ -61,6 +61,7 @@
+ QT_BEGIN_NAMESPACE
+ 
+ static const DWORD VENDOR_ID_AMD = 0x1002;
++static const DWORD VENDOR_ID_INTEL = 0x8086;
+ 
+ static GpuDescription adapterIdentifierToGpuDescription(const D3DADAPTER_IDENTIFIER9 &adapterIdentifier)
+ {
+@@ -141,31 +142,42 @@ GpuDescription GpuDescription::detect()
+         isAMD = result.vendorId == VENDOR_ID_AMD;
+     }
+ 
++    bool isIntel = (result.vendorId == VENDOR_ID_INTEL);
++    bool hasAMD = isAMD;
++    bool hasIntel = isIntel;
++
+     // Detect QTBUG-50371 (having AMD as the default adapter results in a crash
+     // when starting apps on a screen connected to the Intel card) by looking
+     // for a default AMD adapter and an additional non-AMD one.
+-    if (isAMD) {
++	if (true || isAMD) {
+         const UINT adapterCount = direct3D9.adapterCount();
+         for (UINT adp = 1; adp < adapterCount; ++adp) {
+-            if (direct3D9.retrieveAdapterIdentifier(adp, &adapterIdentifier)
+-                && adapterIdentifier.VendorId != VENDOR_ID_AMD) {
+-                // Bingo. Now figure out the display for the AMD card.
+-                DISPLAY_DEVICE dd;
+-                memset(&dd, 0, sizeof(dd));
+-                dd.cb = sizeof(dd);
+-                for (int dev = 0; EnumDisplayDevices(nullptr, dev, &dd, 0); ++dev) {
+-                    if (dd.StateFlags & DISPLAY_DEVICE_PRIMARY_DEVICE) {
+-                        // DeviceName is something like \\.\DISPLAY1 which can be used to
+-                        // match with the MONITORINFOEX::szDevice queried by QWindowsScreen.
+-                        result.gpuSuitableScreen = QString::fromWCharArray(dd.DeviceName);
+-                        break;
++            if (direct3D9.retrieveAdapterIdentifier(adp, &adapterIdentifier)) {
++                if (isAMD && adapterIdentifier.VendorId != VENDOR_ID_AMD) {
++                    // Bingo. Now figure out the display for the AMD card.
++                    DISPLAY_DEVICE dd;
++                    memset(&dd, 0, sizeof(dd));
++                    dd.cb = sizeof(dd);
++                    for (int dev = 0; EnumDisplayDevices(nullptr, dev, &dd, 0); ++dev) {
++                        if (dd.StateFlags & DISPLAY_DEVICE_PRIMARY_DEVICE) {
++                            // DeviceName is something like \\.\DISPLAY1 which can be used to
++                            // match with the MONITORINFOEX::szDevice queried by QWindowsScreen.
++                            result.gpuSuitableScreen = QString::fromWCharArray(dd.DeviceName);
++                            break;
++                        }
+                     }
+                 }
+-                break;
++                if (adapterIdentifier.VendorId == VENDOR_ID_AMD) {
++                    hasAMD = true;
++                } else if (adapterIdentifier.VendorId == VENDOR_ID_INTEL) {
++                    hasIntel = true;
++                }
+             }
+         }
+     }
+ 
++    result.amdSwitchable = hasAMD && hasIntel;
++
+     return result;
+ }
+ 
+@@ -286,6 +298,7 @@ QWindowsOpenGLTester::Renderers QWindowsOpenGLTester::detectSupportedRenderers(c
+     return {};
+ #else
+     QOpenGLConfig::Gpu qgpu = QOpenGLConfig::Gpu::fromDevice(gpu.vendorId, gpu.deviceId, gpu.driverVersion, gpu.description);
++    qgpu.amdSwitchable = gpu.amdSwitchable;
+     SupportedRenderersCache *srCache = supportedRenderersCache();
+     SupportedRenderersCache::const_iterator it = srCache->constFind(qgpu);
+     if (it != srCache->cend())
+diff --git a/src/plugins/platforms/windows/qwindowsopengltester.h b/src/plugins/platforms/windows/qwindowsopengltester.h
+index 9091949699..e106ab87d2 100644
+--- a/src/plugins/platforms/windows/qwindowsopengltester.h
++++ b/src/plugins/platforms/windows/qwindowsopengltester.h
+@@ -65,6 +65,8 @@ struct GpuDescription
+     QByteArray driverName;
+     QByteArray description;
+     QString gpuSuitableScreen;
++
++    bool amdSwitchable = false;
+ };
+ 
+ #ifndef QT_NO_DEBUG_STREAM

--- a/qtbase_6_2_0/0026-gtk-as-last-resort.patch
+++ b/qtbase_6_2_0/0026-gtk-as-last-resort.patch
@@ -1,0 +1,63 @@
+diff --git a/src/gui/platform/unix/qgenericunixthemes.cpp b/src/gui/platform/unix/qgenericunixthemes.cpp
+index 86f2a266ea..f1bfd69835 100644
+--- a/src/gui/platform/unix/qgenericunixthemes.cpp
++++ b/src/gui/platform/unix/qgenericunixthemes.cpp
+@@ -76,6 +76,10 @@
+ 
+ #include <algorithm>
+ 
++#if QT_CONFIG(dlopen)
++#include <dlfcn.h>
++#endif
++
+ QT_BEGIN_NAMESPACE
+ 
+ Q_DECLARE_LOGGING_CATEGORY(qLcTray)
+@@ -853,24 +857,12 @@ QStringList QGenericUnixTheme::themeNames()
+     QStringList result;
+     if (QGuiApplication::desktopSettingsAware()) {
+         const QByteArray desktopEnvironment = QGuiApplicationPrivate::platformIntegration()->services()->desktopEnvironment();
+-        QList<QByteArray> gtkBasedEnvironments;
+-        gtkBasedEnvironments << "GNOME"
+-                             << "X-CINNAMON"
+-                             << "UNITY"
+-                             << "MATE"
+-                             << "XFCE"
+-                             << "LXDE";
+         const QList<QByteArray> desktopNames = desktopEnvironment.split(':');
+         for (const QByteArray &desktopName : desktopNames) {
+             if (desktopEnvironment == "KDE") {
+ #if QT_CONFIG(settings)
+                 result.push_back(QLatin1String(QKdeTheme::name));
+ #endif
+-            } else if (gtkBasedEnvironments.contains(desktopName)) {
+-                // prefer the GTK3 theme implementation with native dialogs etc.
+-                result.push_back(QStringLiteral("gtk3"));
+-                // fallback to the generic Gnome theme if loading the GTK3 theme fails
+-                result.push_back(QLatin1String(QGnomeTheme::name));
+             } else {
+                 // unknown, but lowercase the name (our standard practice) and
+                 // remove any "x-" prefix
+@@ -878,6 +870,22 @@ QStringList QGenericUnixTheme::themeNames()
+                 result.push_back(s.startsWith(QLatin1String("x-")) ? s.mid(2) : s);
+             }
+         }
++        if (!result.contains(QLatin1String(QKdeTheme::name))) {
++#if QT_CONFIG(dlopen)
++            if (const auto handle = dlopen("libgtk-3.so.0", RTLD_LAZY)) {
++                // prefer the GTK3 theme implementation with native dialogs etc.
++                result.push_back(QStringLiteral("gtk3"));
++                dlclose(handle);
++            } else {
++                Q_UNUSED(dlerror());
++            }
++#else
++            // prefer the GTK3 theme implementation with native dialogs etc.
++            result.push_back(QStringLiteral("gtk3"));
++#endif
++            // fallback to the generic Gnome theme if loading the GTK3 theme fails
++            result.push_back(QLatin1String(QGnomeTheme::name));
++        }
+     } // desktopSettingsAware
+     result.append(QLatin1String(QGenericUnixTheme::name));
+     return result;

--- a/qtbase_6_2_0/0027-reset-current-context-on-error.patch
+++ b/qtbase_6_2_0/0027-reset-current-context-on-error.patch
@@ -1,0 +1,57 @@
+diff --git a/src/gui/kernel/qopenglcontext.cpp b/src/gui/kernel/qopenglcontext.cpp
+index 927e9cb94a..cab2740a4b 100644
+--- a/src/gui/kernel/qopenglcontext.cpp
++++ b/src/gui/kernel/qopenglcontext.cpp
+@@ -989,8 +989,17 @@ bool QOpenGLContext::makeCurrent(QSurface *surface)
+         return false;
+     }
+ 
+-    if (!d->platformGLContext->makeCurrent(surface->surfaceHandle()))
++    if (!d->platformGLContext->makeCurrent(surface->surfaceHandle())) {
++        // In this place the context could switch from isValid to !isValid.
++        // It may still be current (from the previous successful calls),
++        // so we need to make everything look as if it was not set current.
++        if (QOpenGLContext::currentContext() == this) {
++            // resources?..
++            QOpenGLContextPrivate::setCurrentContext(nullptr);
++            d->surface = nullptr;
++        }
+         return false;
++    }
+ 
+     QOpenGLContextPrivate::setCurrentContext(this);
+ #ifndef QT_NO_DEBUG
+@@ -1054,8 +1063,14 @@ bool QOpenGLContext::makeCurrent(QSurface *surface)
+ void QOpenGLContext::doneCurrent()
+ {
+     Q_D(QOpenGLContext);
+-    if (!isValid())
++    if (!isValid()) {
++        if (QOpenGLContext::currentContext() == this) {
++            // resources?..
++            QOpenGLContextPrivate::setCurrentContext(nullptr);
++            d->surface = nullptr;
++        }
+         return;
++    }
+ 
+     if (QOpenGLContext::currentContext() == this)
+         d->shareGroup->d_func()->deletePendingResources(this);
+@@ -1118,6 +1133,17 @@ void QOpenGLContext::swapBuffers(QSurface *surface)
+     if (surface->format().swapBehavior() == QSurfaceFormat::SingleBuffer)
+         functions()->glFlush();
+     d->platformGLContext->swapBuffers(surfaceHandle);
++
++    if (!isValid()) {
++        // The swapBuffers call could switch the context from isValid to !isValid.
++        // It may still be current (from the previous successful calls),
++        // so we need to make everything look as if it was not set current.
++        if (QOpenGLContext::currentContext() == this) {
++            // resources?..
++            QOpenGLContextPrivate::setCurrentContext(nullptr);
++            d->surface = nullptr;
++        }
++    }
+ }
+ 
+ /*!

--- a/qtbase_6_2_0/0028-reset-opengl-widget-on-context-loss.patch
+++ b/qtbase_6_2_0/0028-reset-opengl-widget-on-context-loss.patch
@@ -1,0 +1,145 @@
+diff --git a/src/opengl/qplatformbackingstoreopenglsupport.cpp b/src/opengl/qplatformbackingstoreopenglsupport.cpp
+index 30532c5b4b..11d43fc67b 100644
+--- a/src/opengl/qplatformbackingstoreopenglsupport.cpp
++++ b/src/opengl/qplatformbackingstoreopenglsupport.cpp
+@@ -147,11 +147,13 @@ QPlatformBackingStoreOpenGLSupport::~QPlatformBackingStoreOpenGLSupport() {
+         QOffscreenSurface offscreenSurface;
+         offscreenSurface.setFormat(context->format());
+         offscreenSurface.create();
+-        context->makeCurrent(&offscreenSurface);
+-        if (textureId)
+-            context->functions()->glDeleteTextures(1, &textureId);
+-        if (blitter)
+-            blitter->destroy();
++        if (context->makeCurrent(&offscreenSurface)) {
++            // Trying to fix a crash on context loss.
++            if (textureId)
++                context->functions()->glDeleteTextures(1, &textureId);
++            if (blitter)
++                blitter->destroy();
++        }
+     }
+     delete blitter;
+ }
+diff --git a/src/openglwidgets/qopenglwidget.cpp b/src/openglwidgets/qopenglwidget.cpp
+index 2ae1a7f215..6ceca4df87 100644
+--- a/src/openglwidgets/qopenglwidget.cpp
++++ b/src/openglwidgets/qopenglwidget.cpp
+@@ -591,9 +591,11 @@ void QOpenGLWidgetPaintDevice::ensureActiveTarget()
+     if (!wd->initialized)
+         return;
+ 
+-    if (QOpenGLContext::currentContext() != wd->context)
++    if (QOpenGLContext::currentContext() != wd->context) {
+         d->w->makeCurrent();
+-    else
++        if (!wd->initialized)
++            return; // Trying to fix a crash on context loss.
++    } else
+         wd->fbo->bind();
+ 
+     if (!wd->inPaintGL)
+@@ -673,7 +675,11 @@ void QOpenGLWidgetPrivate::recreateFbo()
+ 
+     emit q->aboutToResize();
+ 
+-    context->makeCurrent(surface);
++    if (!context->makeCurrent(surface)) {
++        // Trying to fix a crash on context loss.
++        reset();
++        return;
++    }
+ 
+     delete fbo;
+     fbo = nullptr;
+@@ -714,6 +720,9 @@ void QOpenGLWidgetPrivate::beginCompose()
+     if (flushPending) {
+         flushPending = false;
+         q->makeCurrent();
++        if (!initialized) {
++            return;
++        }
+         static_cast<QOpenGLExtensions *>(context->functions())->flushShared();
+     }
+     hasBeenComposed = true;
+@@ -756,6 +765,7 @@ void QOpenGLWidgetPrivate::initialize()
+     }
+     if (Q_UNLIKELY(!ctx->create())) {
+         qWarning("QOpenGLWidget: Failed to create context");
++        reset();
+         return;
+     }
+ 
+@@ -786,6 +796,7 @@ void QOpenGLWidgetPrivate::initialize()
+ 
+     if (Q_UNLIKELY(!ctx->makeCurrent(surface))) {
+         qWarning("QOpenGLWidget: Failed to make context current");
++        reset();
+         return;
+     }
+ 
+@@ -804,6 +815,9 @@ void QOpenGLWidgetPrivate::resolveSamples()
+     Q_Q(QOpenGLWidget);
+     if (resolvedFbo) {
+         q->makeCurrent();
++        if (!initialized) {
++            return;
++        }
+         QRect rect(QPoint(0, 0), fbo->size());
+         QOpenGLFramebufferObject::blitFramebuffer(resolvedFbo, rect, fbo, rect);
+         flushPending = true;
+@@ -837,6 +851,8 @@ void QOpenGLWidgetPrivate::render()
+         return;
+ 
+     q->makeCurrent();
++    if (!initialized)
++        return; // Trying to fix a crash on context loss.
+ 
+     if (updateBehavior == QOpenGLWidget::NoPartialUpdate && hasBeenComposed) {
+         invalidateFbo();
+@@ -883,14 +899,21 @@ QImage QOpenGLWidgetPrivate::grabFramebuffer()
+     if (!fbo) // could be completely offscreen, without ever getting a resize event
+         recreateFbo();
+ 
++    if (!fbo)
++        return QImage(); // Trying to fix a crash on context loss.
++
+     if (!inPaintGL)
+         render();
+ 
+     if (resolvedFbo) {
+         resolveSamples();
++        if (!initialized)
++            return QImage(); // Trying to fix a crash on context loss.
+         resolvedFbo->bind();
+     } else {
+         q->makeCurrent();
++        if (!initialized)
++            return QImage(); // Trying to fix a crash on context loss.
+     }
+ 
+     const bool hasAlpha = q->format().hasAlpha();
+@@ -1100,7 +1123,12 @@ void QOpenGLWidget::makeCurrent()
+     if (!d->initialized)
+         return;
+ 
+-    d->context->makeCurrent(d->surface);
++    if (!d->context->makeCurrent(d->surface)) {
++        // Trying to fix a crash on context loss.
++        // If makeCurrent() failed, that means we're not initialized any more.
++        d->initialized = false; // This prevents infinite recursion to makeCurrent().
++        d->reset();
++    }
+ 
+     if (d->fbo) // there may not be one if we are in reset()
+         d->fbo->bind();
+@@ -1230,6 +1258,9 @@ void QOpenGLWidget::resizeEvent(QResizeEvent *e)
+         return;
+ 
+     d->recreateFbo();
++    if (!d->fbo)
++        return; // Trying to fix a crash on context loss.
++
+     resizeGL(width(), height());
+     d->sendPaintEvent(QRect(QPoint(0, 0), size()));
+ }

--- a/qtbase_6_2_0/0029-fallback-in-qxcbglxwindow-createvisual.patch
+++ b/qtbase_6_2_0/0029-fallback-in-qxcbglxwindow-createvisual.patch
@@ -1,0 +1,28 @@
+diff --git a/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qxcbglxwindow.cpp b/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qxcbglxwindow.cpp
+index 5e406017ca..0adf030b63 100644
+--- a/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qxcbglxwindow.cpp
++++ b/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qxcbglxwindow.cpp
+@@ -58,7 +58,7 @@ const xcb_visualtype_t *QXcbGlxWindow::createVisual()
+ {
+     QXcbScreen *scr = xcbScreen();
+     if (!scr)
+-        return nullptr;
++        return QXcbWindow::createVisual();
+ 
+     qCDebug(lcQpaGl) << "Requested format before FBConfig/Visual selection:" << m_format;
+ 
+@@ -71,10 +71,12 @@ const xcb_visualtype_t *QXcbGlxWindow::createVisual()
+             flags |= QGLX_SUPPORTS_SRGB;
+     }
+ 
++    const auto formatBackup = m_format;
+     XVisualInfo *visualInfo = qglx_findVisualInfo(dpy, scr->screenNumber(), &m_format, GLX_WINDOW_BIT, flags);
+     if (!visualInfo) {
+-        qWarning() << "No XVisualInfo for format" << m_format;
+-        return nullptr;
++        // restore initial format before requesting it again
++        m_format = formatBackup;
++        return QXcbWindow::createVisual();
+     }
+     const xcb_visualtype_t *xcb_visualtype = scr->visualForId(visualInfo->visualid);
+     XFree(visualInfo);

--- a/qtbase_6_2_0/0030-epoxy.patch
+++ b/qtbase_6_2_0/0030-epoxy.patch
@@ -1,0 +1,56 @@
+diff --git a/src/plugins/platforms/xcb/gl_integrations/xcb_egl/qxcbeglmain.cpp b/src/plugins/platforms/xcb/gl_integrations/xcb_egl/qxcbeglmain.cpp
+index 8979c0371b..1a65eeca25 100644
+--- a/src/plugins/platforms/xcb/gl_integrations/xcb_egl/qxcbeglmain.cpp
++++ b/src/plugins/platforms/xcb/gl_integrations/xcb_egl/qxcbeglmain.cpp
+@@ -41,6 +41,10 @@
+ 
+ #include "qxcbeglintegration.h"
+ 
++#ifdef QT_STATICPLUGIN
++extern "C" bool epoxy_load_egl(bool exit_if_fails, bool load);
++#endif
++
+ QT_BEGIN_NAMESPACE
+ 
+ class QXcbEglIntegrationPlugin : public QXcbGlIntegrationPlugin
+@@ -50,6 +54,12 @@ class QXcbEglIntegrationPlugin : public QXcbGlIntegrationPlugin
+ public:
+     QXcbGlIntegration *create() override
+     {
++#ifdef QT_STATICPLUGIN
++        if (!epoxy_load_egl(false, true)) {
++            return nullptr;
++        }
++#endif
++
+         return new QXcbEglIntegration();
+     }
+ 
+diff --git a/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qxcbglxmain.cpp b/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qxcbglxmain.cpp
+index 898ee3dcf8..79b85d6790 100644
+--- a/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qxcbglxmain.cpp
++++ b/src/plugins/platforms/xcb/gl_integrations/xcb_glx/qxcbglxmain.cpp
+@@ -41,6 +41,10 @@
+ 
+ #include "qxcbglxintegration.h"
+ 
++#ifdef QT_STATICPLUGIN
++extern "C" bool epoxy_load_glx(bool exit_if_fails, bool load);
++#endif
++
+ QT_BEGIN_NAMESPACE
+ 
+ class QXcbGlxIntegrationPlugin : public QXcbGlIntegrationPlugin
+@@ -50,6 +54,12 @@ class QXcbGlxIntegrationPlugin : public QXcbGlIntegrationPlugin
+ public:
+     QXcbGlIntegration *create() override
+     {
++#ifdef QT_STATICPLUGIN
++        if (!epoxy_load_glx(false, true)) {
++            return nullptr;
++        }
++#endif
++
+         return new QXcbGlxIntegration();
+     }
+ 

--- a/qtbase_6_2_0/0031-optional-glib.patch
+++ b/qtbase_6_2_0/0031-optional-glib.patch
@@ -1,0 +1,31 @@
+diff --git a/src/corelib/kernel/qeventdispatcher_glib.cpp b/src/corelib/kernel/qeventdispatcher_glib.cpp
+index 3964c1ceac..9a19006f0f 100644
+--- a/src/corelib/kernel/qeventdispatcher_glib.cpp
++++ b/src/corelib/kernel/qeventdispatcher_glib.cpp
+@@ -50,6 +50,10 @@
+ 
+ #include <glib.h>
+ 
++#if QT_CONFIG(dlopen)
++#include <dlfcn.h>
++#endif
++
+ QT_BEGIN_NAMESPACE
+ 
+ struct GPollFDWithQSocketNotifier
+@@ -598,6 +602,15 @@ void QEventDispatcherGlib::wakeUp()
+ 
+ bool QEventDispatcherGlib::versionSupported()
+ {
++#if QT_CONFIG(dlopen)
++    const auto handle = dlopen("libglib-2.0.so.0", RTLD_LAZY);
++    if (!handle) {
++        Q_UNUSED(dlerror());
++        return false;
++    }
++    dlclose(handle);
++#endif
++
+ #if !defined(GLIB_MAJOR_VERSION) || !defined(GLIB_MINOR_VERSION) || !defined(GLIB_MICRO_VERSION)
+     return false;
+ #else

--- a/qtbase_6_2_0/0032-no-gl-in-qtgui.patch
+++ b/qtbase_6_2_0/0032-no-gl-in-qtgui.patch
@@ -1,0 +1,13 @@
+diff --git a/src/opengl/qopenglpaintengine.cpp b/src/opengl/qopenglpaintengine.cpp
+index 8606a2e7ef..f3ee31ed68 100644
+--- a/src/opengl/qopenglpaintengine.cpp
++++ b/src/opengl/qopenglpaintengine.cpp
+@@ -686,7 +686,7 @@ void QOpenGL2PaintEngineEx::beginNativePainting()
+     for (int i = 0; i < QT_GL_VERTEX_ARRAY_TRACKED_COUNT; ++i)
+         d->funcs.glDisableVertexAttribArray(i);
+ 
+-#if !QT_CONFIG(opengles2) && !defined(QT_OPENGL_DYNAMIC)
++#if 0
+     Q_ASSERT(QOpenGLContext::currentContext());
+     const QOpenGLContext *ctx = d->ctx;
+     const QSurfaceFormat &fmt = d->device->context()->format();

--- a/qtbase_6_2_0/0033-fix-build-without-pch.patch
+++ b/qtbase_6_2_0/0033-fix-build-without-pch.patch
@@ -1,0 +1,14 @@
+diff --git a/configure.cmake b/configure.cmake
+index 5705e37611..ffc1a0e5c4 100644
+--- a/configure.cmake
++++ b/configure.cmake
+@@ -588,8 +588,7 @@ qt_feature("c11" PUBLIC
+ )
+ qt_feature("precompile_header"
+     LABEL "Using precompiled headers"
+-    CONDITION BUILD_WITH_PCH AND TEST_precompile_header
+-    AUTODETECT NOT WASM
++    AUTODETECT BUILD_WITH_PCH AND TEST_precompile_header AND NOT WASM
+ )
+ qt_feature_config("precompile_header" QMAKE_PRIVATE_CONFIG)
+ set(__qt_ltcg_detected FALSE)

--- a/qtwayland_6_2_0/0001-clipboard-fix-non-bmp.patch
+++ b/qtwayland_6_2_0/0001-clipboard-fix-non-bmp.patch
@@ -1,0 +1,61 @@
+From 6072c1dc87e185f30c014f764737ac97b906640f Mon Sep 17 00:00:00 2001
+From: Jan Blackquill <uhhadd@gmail.com>
+Date: Tue, 24 Aug 2021 14:36:34 -0400
+Subject: [PATCH] Correctly detect if image format is supported by QImageWriter
+
+The code queries potential image formats by stripping a mimetype of its
+'image/' prefix and making the rest of the mimetype capitalised, such as
+'image/png' -> 'PNG'. The problem is that this is then searched for in
+QImageWriter::supportedImageFormats() by simple equality. The method
+returns a list of lowercase byte arrays, not uppercase. As the codepath
+can never match due to checking for an uppercase word in an array of
+lowercase words, this means that images are effectively always sent as
+BMP format, even if they should be sent in other formats, such as PNG
+or JPEG.
+
+A simple inspection with GDB (or a qDebug) reveals this:
+
+```
+(gdb) p QImageWriter::supportedImageFormats()
+$31 = {"bmp" = {...}, "bw" = {...}, "cur" = {...}, "eps" = {...},
+  "epsf" = {...}, "epsi" = {...}, "icns" = {...},
+  "ico" = {...}, "jp2" = {...}, "jpeg" = {...}, "jpg" = {...},
+  "pbm" = {...}, "pcx" = {...}, "pgm" = {...},
+  "pic" = {...}, "png" = {...}, "ppm" = {...},
+  "rgb" = {...}, "rgba" = {...}, "sgi" = {...},
+  "tga" = {...}, "tif" = {...}, "tiff" = {...},
+  "wbmp" = {...}, "webp" = {...}, "xbm" = {...}, "xpm" = {...}}
+```
+
+```
+(gdb) p QImageWriter::supportedImageFormats().contains("PNG")
+$32 = false
+```
+
+```
+(gdb) p QImageWriter::supportedImageFormats().contains("png")
+$33 = true
+```
+
+The fix for this is simple: lowercase the remainder of the mimetype,
+instead of uppercasing it, and we can start hitting the codepath that's
+supposed to write non-BMP formats.
+
+Change-Id: Id3e9b730b7edcabcb2f1b04d8ef0a4c1fb9c9159
+Reviewed-by: David Edmundson <davidedmundson@kde.org>
+Reviewed-by: Qt CI Bot <qt_ci_bot@qt-project.org>
+---
+
+diff --git a/src/shared/qwaylandmimehelper.cpp b/src/shared/qwaylandmimehelper.cpp
+index a5fdd34..051a91d 100644
+--- a/src/shared/qwaylandmimehelper.cpp
++++ b/src/shared/qwaylandmimehelper.cpp
+@@ -60,7 +60,7 @@
+             buf.open(QIODevice::ReadWrite);
+             QByteArray fmt = "BMP";
+             if (mimeType.startsWith(QLatin1String("image/"))) {
+-                QByteArray imgFmt = mimeType.mid(6).toUpper().toLatin1();
++                QByteArray imgFmt = mimeType.mid(6).toLower().toLatin1();
+                 if (QImageWriter::supportedImageFormats().contains(imgFmt))
+                     fmt = imgFmt;
+             }

--- a/qtwayland_6_2_0/0002-epoxy.patch
+++ b/qtwayland_6_2_0/0002-epoxy.patch
@@ -1,0 +1,28 @@
+diff --git a/src/plugins/hardwareintegration/client/wayland-egl/main.cpp b/src/plugins/hardwareintegration/client/wayland-egl/main.cpp
+index 11bf5806..8b073f02 100644
+--- a/src/plugins/hardwareintegration/client/wayland-egl/main.cpp
++++ b/src/plugins/hardwareintegration/client/wayland-egl/main.cpp
+@@ -40,6 +40,10 @@
+ #include <QtWaylandClient/private/qwaylandclientbufferintegrationplugin_p.h>
+ #include <QtWaylandEglClientHwIntegration/private/qwaylandeglclientbufferintegration_p.h>
+ 
++#ifdef QT_STATICPLUGIN
++extern "C" bool epoxy_load_egl(bool exit_if_fails, bool load);
++#endif
++
+ QT_BEGIN_NAMESPACE
+ 
+ namespace QtWaylandClient {
+@@ -54,6 +58,12 @@ public:
+ 
+ QWaylandClientBufferIntegration *QWaylandEglClientBufferPlugin::create(const QString&, const QStringList&)
+ {
++#ifdef QT_STATICPLUGIN
++    if (!epoxy_load_egl(false, true)) {
++        return nullptr;
++    }
++#endif
++
+     return new QWaylandEglClientBufferIntegration();
+ }
+ 


### PR DESCRIPTION
The list of removed patches:
* fix-cjk-font-fallback, fix-accent-menu-on-macos - should be fixed in Qt 6, according to bugtracker at least
* enable-macos-10-12, fix-qcocoacolordialoghelper-for-10-12, fix-qcocoadrag-for-10-12, fix-qrhimetal-for-10-12, fix-qcocoawindow-for-10-12 - Qt raised minimal macOS version, so they're useless
* qinputcontrol-accept-surrogate-category-character, Windows-QPA-Fix-missing-QScreen-change-updates, backport-QEventDispatcherWin32-deadlock-fix, fix-xcb-clipboard-pasting, fix-build-with-gcc-11, client-Allow-QWaylandInputContext-to-accept-composed - backports
* get-dpi-from-xsettings - upstreamed
* no-dynamic-opengl-es2, fix-build-with-new-angle-headers, env-select-static-angle-backend, use-bgra-texture-format-for-angle - Qt removed ANGLE support

The port of fix-shortcuts-on-macos is incomplete, the place where code was changed for fixing QTBUG-42584 is different enough now and it's not clear whether the bug affects macOS 10.11+ or not