### PR TITLE
Always link dl publically

### DIFF
--- a/qtbase_6_2_0/0014-old-freetype-compatibility.patch
+++ b/qtbase_6_2_0/0014-old-freetype-compatibility.patch
@@ -1,16 +1,3 @@
-diff --git a/src/gui/CMakeLists.txt b/src/gui/CMakeLists.txt
-index 905afd4038..0e929b58e0 100644
---- a/src/gui/CMakeLists.txt
-+++ b/src/gui/CMakeLists.txt
-@@ -843,7 +843,7 @@ qt_internal_extend_target(Gui CONDITION QT_FEATURE_egl AND NOT QT_FEATURE_egl_x1
-         QT_EGL_NO_X11
- )
- 
--qt_internal_extend_target(Gui CONDITION QT_FEATURE_dlopen AND QT_FEATURE_egl
-+qt_internal_extend_target(Gui CONDITION QT_FEATURE_dlopen AND (QT_FEATURE_egl OR QT_FEATURE_system_freetype)
-     LIBRARIES
-         ${CMAKE_DL_LIBS}
- )
 diff --git a/src/gui/text/freetype/qfontengine_ft.cpp b/src/gui/text/freetype/qfontengine_ft.cpp
 index 12ba46b7ed..8dc43f3113 100644
 --- a/src/gui/text/freetype/qfontengine_ft.cpp

--- a/qtbase_6_2_0/0048-qtgui-dlopen.patch
+++ b/qtbase_6_2_0/0048-qtgui-dlopen.patch
@@ -1,0 +1,15 @@
+diff --git a/src/gui/CMakeLists.txt b/src/gui/CMakeLists.txt
+index 905afd4038..4715a8b31e 100644
+--- a/src/gui/CMakeLists.txt
++++ b/src/gui/CMakeLists.txt
+@@ -843,8 +843,8 @@ qt_internal_extend_target(Gui CONDITION QT_FEATURE_egl AND NOT QT_FEATURE_egl_x1
+         QT_EGL_NO_X11
+ )
+ 
+-qt_internal_extend_target(Gui CONDITION QT_FEATURE_dlopen AND QT_FEATURE_egl
+-    LIBRARIES
++qt_internal_extend_target(Gui CONDITION QT_FEATURE_dlopen
++    PUBLIC_LIBRARIES
+         ${CMAKE_DL_LIBS}
+ )
+ 


### PR DESCRIPTION
It's needed for multiple features in the patchs and can be passthorugh to other libraries due to GL (epoxy) public link