### PR TITLE
Let Qt fallback to X11 if shell integration failed

### DIFF
--- a/qtwayland_6_2_0/0004-check-shellintegration.patch
+++ b/qtwayland_6_2_0/0004-check-shellintegration.patch
@@ -1,0 +1,44 @@
+diff --git a/src/client/qwaylanddisplay.cpp b/src/client/qwaylanddisplay.cpp
+index 8806773d..c4e251e9 100644
+--- a/src/client/qwaylanddisplay.cpp
++++ b/src/client/qwaylanddisplay.cpp
+@@ -163,6 +163,13 @@ QWaylandDisplay::QWaylandDisplay(QWaylandIntegration *waylandIntegration)
+     if (!mXkbContext)
+         qCWarning(lcQpaWayland, "failed to create xkb context");
+ #endif
++
++    forceRoundTrip();
++
++    if (!mWaitingScreens.isEmpty()) {
++        // Give wl_output.done and zxdg_output_v1.done events a chance to arrive
++        forceRoundTrip();
++    }
+ }
+ 
+ QWaylandDisplay::~QWaylandDisplay(void)
+@@ -191,12 +198,6 @@ QWaylandDisplay::~QWaylandDisplay(void)
+ // so that factory functions in integration can be overridden.
+ void QWaylandDisplay::initialize()
+ {
+-    forceRoundTrip();
+-
+-    if (!mWaitingScreens.isEmpty()) {
+-        // Give wl_output.done and zxdg_output_v1.done events a chance to arrive
+-        forceRoundTrip();
+-    }
+ }
+ 
+ void QWaylandDisplay::ensureScreen()
+diff --git a/src/client/qwaylandintegration.cpp b/src/client/qwaylandintegration.cpp
+index 41e6c50f..728d4d5a 100644
+--- a/src/client/qwaylandintegration.cpp
++++ b/src/client/qwaylandintegration.cpp
+@@ -115,7 +115,7 @@ QWaylandIntegration::QWaylandIntegration()
+ #endif
+ {
+     mDisplay.reset(new QWaylandDisplay(this));
+-    if (!mDisplay->isInitialized()) {
++    if (!mDisplay->isInitialized() || !shellIntegration()) {
+         mFailed = true;
+         return;
+     }


### PR DESCRIPTION
Fixes https://github.com/telegramdesktop/tdesktop/issues/17210