### PR TITLE
Add ARM to libproxy.patch

### DIFF
--- a/libproxy.patch
+++ b/libproxy.patch
@@ -72,7 +72,7 @@ diff --git a/libproxy/modules/config_gnome3.cpp b/libproxy/modules/config_gnome3
 index b4424e6..1f2dd2a 100644
 --- a/libproxy/modules/config_gnome3.cpp
 +++ b/libproxy/modules/config_gnome3.cpp
-@@ -27,12 +27,22 @@
+@@ -27,12 +27,79 @@
  #include <sys/wait.h>     // For waitpid()
  #include <signal.h>       // For kill()
  #include <string.h>       // For memset() [used in FD_ZERO() on Solaris]
@@ -83,8 +83,65 @@ index b4424e6..1f2dd2a 100644
  
  #define BUFFERSIZE 10240
  
-+#if defined _M_X64 || defined __x86_64__
-+#define DEBIAN_LIB_ARCH_DIR "x86_64-linux-gnu"
++#if defined(_MSC_VER)
++#  if defined(_M_X64) || defined (_M_AMD64)
++#    define DEBIAN_LIB_ARCH_DIR "x86_64-linux-gnu"
++#  elif defined(_M_ARM) || defined(_M_ARM_ARMV7VE) || defined(_M_ARM_FP)
++#    if defined(__ARM_EABI__) && defined(__ARM_PCS_VFP)
++#      define DEBIAN_LIB_ARCH_DIR "arm-linux-gnueabihf"
++#    elif defined(__ARM_EABI__)
++#      define DEBIAN_LIB_ARCH_DIR "arm-linux-gnueabi"
++#    else
++#      define DEBIAN_LIB_ARCH_DIR "arm-linux-gnu"
++#    endif
++#  elif defined(_M_ARM64)
++#    define DEBIAN_LIB_ARCH_DIR "aarch64-linux-gnu"
++#  endif
++#elif defined(__GNUC__)
++#  if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
++#    if (defined(__BYTE_ORDER__)  && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) || \
++       (defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN) || \
++       defined(__ARMEB__) || defined(__THUMBEB__) || defined(__AARCH64EB__)
++#      define __BIG_ENDIAN__
++#    elif (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) || \
++       (defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN) || \
++       defined(__ARMEL__) || defined(__THUMBEL__) || defined(__AARCH64EL__)
++#      define __LITTLE_ENDIAN__
++#    endif
++#  endif
++#  if defined(__x86_64__) || defined(__amd64__)
++#    define DEBIAN_LIB_ARCH_DIR "x86_64-linux-gnu"
++#  elif defined(__arm__)
++#    if defined(__ARM_EABI__) && defined(__ARM_PCS_VFP)
++#      if defined(__BIG_ENDIAN__)
++#        define DEBIAN_LIB_ARCH_DIR "armeb-linux-gnueabihf"
++#      elif defined(__LITTLE_ENDIAN__)
++#        define DEBIAN_LIB_ARCH_DIR "arm-linux-gnueabihf"
++#      endif
++#    elif defined(__ARM_EABI__)
++#      if defined(__BIG_ENDIAN__)
++#        define DEBIAN_LIB_ARCH_DIR "armeb-linux-gnueabi"
++#      elif defined(__LITTLE_ENDIAN__)
++#        define DEBIAN_LIB_ARCH_DIR "arm-linux-gnueabi"
++#      endif
++#    else
++#      define DEBIAN_LIB_ARCH_DIR "arm-linux-gnu"
++#    endif
++#  elif defined(__aarch64__)
++#    if defined(__ILP32__)
++#      if defined(__BIG_ENDIAN__)
++#        define DEBIAN_LIB_ARCH_DIR "aarch64_be-linux-gnu_ilp32"
++#      elif defined(__LITTLE_ENDIAN__)
++#        define DEBIAN_LIB_ARCH_DIR "aarch64-linux-gnu_ilp32"
++#      endif
++#    elif defined(__LP64__)
++#      if defined(__BIG_ENDIAN__)
++#        define DEBIAN_LIB_ARCH_DIR "aarch64_be-linux-gnu"
++#      elif defined(__LITTLE_ENDIAN__)
++#        define DEBIAN_LIB_ARCH_DIR "aarch64-linux-gnu"
++#      endif
++#    endif
++#  endif
 +#endif
 +
 +#define PXGSETTINGS_LIBEXEC_PATH "/usr/libexec/pxgsettings"


### PR DESCRIPTION
We can use original patch on __x86_x64__, but on another architecture aarch64/arm64 compiler get error. Because the DEBIAN_LIB_ARCH_DIR is in the visibility of the preprocessor and directive block vision of this.