### PR TITLE
libvpx: unset unexpected environment variables inherited from Windows

### DIFF
--- a/build_libvpx_win.sh
+++ b/build_libvpx_win.sh
@@ -8,8 +8,11 @@ pacman --noconfirm -Sy
 pacman --noconfirm -S msys/make
 pacman --noconfirm -S diffutils
 
+unset temp
+unset tmp
+
 ./configure --prefix=$FullScriptPath/../local \
---target=$TARGET \
+--target=$BUILD_TARGET \
 --disable-examples \
 --disable-unit-tests \
 --disable-tools \


### PR DESCRIPTION
The same thing happened in https://github.com/git-tfs/git-tfs/issues/135.

We also need to rename `$TARGET` to `$BUILD_TARGET` to prevent the same issue.