### PR TITLE
Qt 6.3.0 patches

### DIFF
--- a/qtbase_6_2_4/0046-fix-opengl-crash-on-context-loss.patch
+++ b/qtbase_6_2_4/0046-fix-opengl-crash-on-context-loss.patch
@@ -1,0 +1,14 @@
+diff --git a/src/opengl/qopenglpaintengine.cpp b/src/opengl/qopenglpaintengine.cpp
+index f835019136..30553804d8 100644
+--- a/src/opengl/qopenglpaintengine.cpp
++++ b/src/opengl/qopenglpaintengine.cpp
+@@ -2167,7 +2167,8 @@ bool QOpenGL2PaintEngineEx::begin(QPaintDevice *pdev)
+ 
+     d->device->ensureActiveTarget();
+ 
+-    if (d->device->context() != QOpenGLContext::currentContext() || !d->device->context()) {
++    if (!QOpenGLContext::currentContext() || d->device->context() != QOpenGLContext::currentContext()
++        || !d->device->context()) {
+         qWarning("QPainter::begin(): QOpenGLPaintDevice's context needs to be current");
+         return false;
+     }

--- a/qtbase_6_3_0/0001-disable-slow-debug-code.patch
+++ b/qtbase_6_3_0/0001-disable-slow-debug-code.patch
@@ -1,0 +1,14 @@
+diff --git a/src/corelib/kernel/qcore_mac.mm b/src/corelib/kernel/qcore_mac.mm
+index 266faca0ed..38a559877e 100644
+--- a/src/corelib/kernel/qcore_mac.mm
++++ b/src/corelib/kernel/qcore_mac.mm
+@@ -140,7 +140,8 @@ QMacAutoReleasePool::QMacAutoReleasePool()
+ {
+     Class trackerClass = [QMacAutoReleasePoolTracker class];
+ 
+-#ifdef QT_DEBUG
++// Patch: Disable this debug code because it is very slow.
++#if 0
+     void *poolFrame = nullptr;
+     if (__builtin_available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 5.0, *)) {
+         void *frame;

--- a/qtbase_6_3_0/0002-spellcheck-underline-from-chrome.patch
+++ b/qtbase_6_3_0/0002-spellcheck-underline-from-chrome.patch
@@ -1,0 +1,142 @@
+diff --git a/src/gui/painting/qpainter.cpp b/src/gui/painting/qpainter.cpp
+index 13ae30433c..280ebab353 100644
+--- a/src/gui/painting/qpainter.cpp
++++ b/src/gui/painting/qpainter.cpp
+@@ -5994,6 +5994,93 @@ static QPixmap generateWavyPixmap(qreal maxRadius, const QPen &pen)
+     return pixmap;
+ }
+ 
++// Patch: Improved underline with SpellCheck style for macOS and Windows.
++// Added implementation of underline drawing from Chrome.
++static QPixmap generateChromeSpellcheckPixmap(qreal descent, qreal factor, const QPen &pen) {
++    QString key = QLatin1String("ChromeUnderline-")
++        % pen.color().name()
++        % HexString<qreal>(factor)
++        % HexString<qreal>(pen.widthF());
++
++    QPixmap pixmap;
++    if (QPixmapCache::find(key, &pixmap)) {
++        return pixmap;
++    }
++    // https://chromium.googlesource.com/chromium/src/+/refs/heads/master/third_party/blink/renderer/core/paint/document_marker_painter.cc
++
++#ifdef Q_OS_MAC
++    Q_UNUSED(descent);
++
++    constexpr qreal kMarkerHeight = 3;
++
++    const auto ratio = qApp->devicePixelRatio();
++    const qreal height = kMarkerHeight * factor;
++    const qreal width = height + 1;
++
++    pixmap = QPixmap(qCeil(width) * ratio, qFloor(height) * ratio);
++    pixmap.setDevicePixelRatio(ratio);
++    pixmap.fill(Qt::transparent);
++    {
++        QPainter imgPainter(&pixmap);
++        imgPainter.setPen(Qt::NoPen);
++        imgPainter.setBrush(pen.color());
++        imgPainter.setRenderHints(
++            QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
++        imgPainter.drawEllipse(0, 0, qFloor(height), qFloor(height));
++    }
++
++#else
++
++    constexpr qreal kMarkerWidth = 4;
++    constexpr qreal kMarkerHeight = 2;
++
++    const auto x1 = (kMarkerWidth * -3 / 8) * factor;
++    const auto y1 = (kMarkerHeight * 3 / 4) * factor;
++
++    const auto cY = (kMarkerHeight * 1 / 4) * factor;
++
++    const auto c1X1 = (kMarkerWidth * -1 / 8) * factor;
++    const auto c1X2 = (kMarkerWidth * 3 / 8) * factor;
++    const auto c1X3 = (kMarkerWidth * 7 / 8) * factor;
++
++    const auto c2X1 = (kMarkerWidth * 1 / 8) * factor;
++    const auto c2X2 = (kMarkerWidth * 5 / 8) * factor;
++    const auto c2X3 = (kMarkerWidth * 9 / 8) * factor;
++
++    QPainterPath path;
++    path.moveTo(x1, y1);
++    path.cubicTo(c1X1, y1,
++        c1X1, cY,
++        c2X1, cY);
++    path.cubicTo(c1X2, cY,
++        c1X2, y1,
++        c2X2, y1);
++    path.cubicTo(c1X3, y1,
++        c1X3, cY,
++        c2X3, cY);
++
++    pixmap = QPixmap(kMarkerWidth * factor, kMarkerHeight * factor * 2);
++    pixmap.fill(Qt::transparent);
++    {
++        QPen wavePen = pen;
++        wavePen.setCapStyle(Qt::RoundCap);
++        wavePen.setJoinStyle(Qt::RoundJoin);
++        wavePen.setWidthF(1 * factor);
++
++        QPainter imgPainter(&pixmap);
++        imgPainter.setPen(std::move(wavePen));
++        imgPainter.setRenderHint(QPainter::Antialiasing);
++        imgPainter.translate(0, descent - (kMarkerHeight * factor));
++        imgPainter.drawPath(std::move(path));
++    }
++
++#endif
++
++    QPixmapCache::insert(std::move(key), pixmap);
++
++    return pixmap;
++}
++
+ static void drawTextItemDecoration(QPainter *painter, const QPointF &pos, const QFontEngine *fe, QTextEngine *textEngine,
+                                    QTextCharFormat::UnderlineStyle underlineStyle,
+                                    QTextItem::RenderFlags flags, qreal width,
+@@ -6011,18 +6098,36 @@ static void drawTextItemDecoration(QPainter *painter, const QPointF &pos, const
+     pen.setWidthF(fe->lineThickness().toReal());
+     pen.setCapStyle(Qt::FlatCap);
+ 
+-    QLineF line(qFloor(pos.x()), pos.y(), qFloor(pos.x() + width), pos.y());
++    // Patch: Improved underline with SpellCheck style for macOS and Windows.
++    // Slightly move the beginning of the underline to the right.
++    QLineF line(qFloor(pos.x() + 1), pos.y(), qFloor(pos.x() + width), pos.y());
+ 
+     const qreal underlineOffset = fe->underlinePosition().toReal();
+ 
+     if (underlineStyle == QTextCharFormat::SpellCheckUnderline) {
+-        QPlatformTheme *theme = QGuiApplicationPrivate::platformTheme();
+-        if (theme)
+-            underlineStyle = QTextCharFormat::UnderlineStyle(theme->themeHint(QPlatformTheme::SpellCheckUnderlineStyle).toInt());
+-        if (underlineStyle == QTextCharFormat::SpellCheckUnderline) // still not resolved
+-            underlineStyle = QTextCharFormat::WaveUnderline;
+-    }
++        const qreal fontFactor = qreal(charFormat.font().pixelSize()) / qreal(10.);
++        painter->save();
++        painter->translate(0, pos.y() + 1);
++        const qreal maxHeight = fe->descent().toReal() - qreal(1);
++
++        QColor uc = charFormat.underlineColor();
++        if (uc.isValid())
++            pen.setColor(uc);
+ 
++        const QPixmap wave = generateChromeSpellcheckPixmap(maxHeight, fontFactor, pen);
++        const int descent = qFloor(maxHeight);
++
++        painter->setBrushOrigin(painter->brushOrigin().x(), 0);
++#ifdef Q_OS_MAC
++        const auto h = wave.height() / qApp->devicePixelRatio();
++        painter->drawTiledPixmap(
++            QRectF(pos.x(), (descent - h) / 2., qCeil(width), h),
++            wave);
++#else
++        painter->fillRect(pos.x(), 0, qCeil(width), descent, wave);
++#endif
++        painter->restore();
++    } else
+     if (underlineStyle == QTextCharFormat::WaveUnderline) {
+         painter->save();
+         painter->translate(0, pos.y() + 1);

--- a/qtbase_6_3_0/0003-improve-apostrophe-processing.patch
+++ b/qtbase_6_3_0/0003-improve-apostrophe-processing.patch
@@ -1,0 +1,169 @@
+diff --git a/src/gui/text/qtextcursor.cpp b/src/gui/text/qtextcursor.cpp
+index a27ef81500..c1ca62f4b9 100644
+--- a/src/gui/text/qtextcursor.cpp
++++ b/src/gui/text/qtextcursor.cpp
+@@ -510,6 +510,9 @@ bool QTextCursorPrivate::movePosition(QTextCursor::MoveOperation op, QTextCursor
+         const int len = blockIt.length() - 1;
+         if (relativePos >= len)
+             return false;
++        // Patch: Improved apostrophe processing.
++        relativePos = engine->toEdge(relativePos, len, true);
++#if 0
+         if (engine->atWordSeparator(relativePos)) {
+             ++relativePos;
+             while (relativePos < len && engine->atWordSeparator(relativePos))
+@@ -518,6 +521,9 @@ bool QTextCursorPrivate::movePosition(QTextCursor::MoveOperation op, QTextCursor
+             while (relativePos < len && !attributes[relativePos].whiteSpace && !engine->atWordSeparator(relativePos))
+                 ++relativePos;
+         }
++#else
++        Q_UNUSED(attributes);
++#endif
+         newPosition = blockIt.position() + relativePos;
+         break;
+     }
+diff --git a/src/gui/text/qtextengine.cpp b/src/gui/text/qtextengine.cpp
+index 74967aeac9..ddc4eb0b65 100644
+--- a/src/gui/text/qtextengine.cpp
++++ b/src/gui/text/qtextengine.cpp
+@@ -2886,7 +2886,8 @@ bool QTextEngine::atWordSeparator(int position) const
+     case '&':
+     case '^':
+     case '*':
+-    case '\'':
++    // Patch: Make the apostrophe a non-separator for words.
++    //case '\'':
+     case '"':
+     case '`':
+     case '~':
+@@ -2899,6 +2900,74 @@ bool QTextEngine::atWordSeparator(int position) const
+     return false;
+ }
+ 
++// Patch: Improved apostrophe processing.
++// We should consider apostrophes as word separators when there is more than
++// one apostrophe in a row, or when the apostrophe is at the beginning or end
++// of the word.
++int QTextEngine::toEdge(int pos, int len, bool isRightDirection) {
++    const auto step = isRightDirection ? 1 : -1;
++    const auto next = isRightDirection ? 0 : -1;
++
++    QCharAttributes *attributes = const_cast<QCharAttributes *>(this->attributes());
++
++    const auto atApostrophe = [&](int position) {
++        return layoutData->string.at(position).unicode() == '\'';
++    };
++
++    const auto atSepOrApost = [&](int position) {
++        return atApostrophe(position) || atWordSeparator(position);
++    };
++
++    const auto inBounds = [&](int position) {
++        return isRightDirection
++            ? position < len
++            : position > 0;
++    };
++
++    const auto atSepOrSpace = [&](int position) {
++        return attributes[position].whiteSpace || atWordSeparator(position);
++    };
++
++    const auto isApostropheInWord = [&](int position) {
++        if (!atApostrophe(position)) {
++            return false;
++        }
++        auto p = position - 1;
++        if (p <= 0 || atSepOrSpace(p)) {
++            return false;
++        }
++        p = position + 1;
++        if (p >= len || atSepOrSpace(p)) {
++            return false;
++        }
++        return true;
++    };
++
++    auto counter = 0;
++    while (inBounds(pos) && atSepOrApost(pos + next)) {
++        counter++;
++        pos += step;
++    }
++    // If it's not the single apostrophe, then that's non-letter part of text.
++    if (counter > 1 || (counter == 1 && !isApostropheInWord(pos - step + next))) {
++        return pos;
++    }
++
++    bool isPrevApostrophe = false;
++    while (inBounds(pos) && !atSepOrSpace(pos + next)) {
++        bool isNextApostrophe = atApostrophe(pos + next);
++        if (isPrevApostrophe && isNextApostrophe) {
++            break;
++        }
++        pos += step;
++        isPrevApostrophe = isNextApostrophe;
++    }
++    if (isPrevApostrophe) {
++        pos += -step;
++    }
++    return pos;
++}
++
+ void QTextEngine::setPreeditArea(int position, const QString &preeditText)
+ {
+     if (preeditText.isEmpty()) {
+diff --git a/src/gui/text/qtextengine_p.h b/src/gui/text/qtextengine_p.h
+index 6ae3196963..e62125f289 100644
+--- a/src/gui/text/qtextengine_p.h
++++ b/src/gui/text/qtextengine_p.h
+@@ -621,6 +621,8 @@ private:
+ 
+ public:
+     bool atWordSeparator(int position) const;
++    // Patch: Improved apostrophe processing.
++    int toEdge(int pos, int len, bool isRightDirection);
+ 
+     QString elidedText(Qt::TextElideMode mode, const QFixed &width, int flags = 0, int from = 0, int count = -1) const;
+ 
+diff --git a/src/gui/text/qtextlayout.cpp b/src/gui/text/qtextlayout.cpp
+index 70e6043231..7b5f333829 100644
+--- a/src/gui/text/qtextlayout.cpp
++++ b/src/gui/text/qtextlayout.cpp
+@@ -673,6 +673,12 @@ int QTextLayout::nextCursorPosition(int oldPos, CursorMode mode) const
+         while (oldPos < len && !attributes[oldPos].graphemeBoundary)
+             oldPos++;
+     } else {
++        // Patch: Skip to the end of the current word, not to the start of the next one.
++        while (oldPos < len && attributes[oldPos].whiteSpace)
++            oldPos++;
++        // Patch: Improved apostrophe processing.
++        oldPos = d->toEdge(oldPos, len, true);
++#if 0
+         if (oldPos < len && d->atWordSeparator(oldPos)) {
+             oldPos++;
+             while (oldPos < len && d->atWordSeparator(oldPos))
+@@ -683,6 +689,7 @@ int QTextLayout::nextCursorPosition(int oldPos, CursorMode mode) const
+         }
+         while (oldPos < len && attributes[oldPos].whiteSpace)
+             oldPos++;
++#endif
+     }
+ 
+     return oldPos;
+@@ -712,6 +719,9 @@ int QTextLayout::previousCursorPosition(int oldPos, CursorMode mode) const
+         while (oldPos > 0 && attributes[oldPos - 1].whiteSpace)
+             oldPos--;
+ 
++        // Patch: Improved apostrophe processing.
++        oldPos = d->toEdge(oldPos, len, false);
++#if 0
+         if (oldPos && d->atWordSeparator(oldPos-1)) {
+             oldPos--;
+             while (oldPos && d->atWordSeparator(oldPos-1))
+@@ -720,6 +730,7 @@ int QTextLayout::previousCursorPosition(int oldPos, CursorMode mode) const
+             while (oldPos > 0 && !attributes[oldPos - 1].whiteSpace && !d->atWordSeparator(oldPos-1))
+                 oldPos--;
+         }
++#endif
+     }
+ 
+     return oldPos;

--- a/qtbase_6_3_0/0004-fix-shortcuts-on-macos.patch
+++ b/qtbase_6_3_0/0004-fix-shortcuts-on-macos.patch
@@ -1,0 +1,57 @@
+diff --git a/src/gui/platform/darwin/qapplekeymapper.mm b/src/gui/platform/darwin/qapplekeymapper.mm
+index bdf741573d..ae3e24fbbc 100644
+--- a/src/gui/platform/darwin/qapplekeymapper.mm
++++ b/src/gui/platform/darwin/qapplekeymapper.mm
+@@ -608,8 +608,8 @@ QList<int> QAppleKeyMapper::possibleKeys(const QKeyEvent *event) const
+         if ((eventModifiers & candidateModifiers) == candidateModifiers) {
+             // If the event includes more modifiers than the candidate they
+             // will need to be included in the resulting key combination.
+-            auto additionalModifiers = eventModifiers & ~candidateModifiers;
+-            ret << int(additionalModifiers) + int(keyAfterApplyingModifiers);
++            // Patch: Fix non-english layout global shortcuts.
++            ret << int(candidateModifiers) + int(keyAfterApplyingModifiers);
+         }
+     }
+ 
+diff --git a/src/plugins/platforms/cocoa/qnsview_keys.mm b/src/plugins/platforms/cocoa/qnsview_keys.mm
+index dbcab6c6d1..fd9988301a 100644
+--- a/src/plugins/platforms/cocoa/qnsview_keys.mm
++++ b/src/plugins/platforms/cocoa/qnsview_keys.mm
+@@ -161,6 +161,23 @@
+         [super keyUp:nsevent];
+ }
+ 
++// Patch: Enable Ctrl+Tab and Ctrl+Shift+Tab / Ctrl+Backtab handle in-app.
++- (BOOL)performKeyEquivalent:(NSEvent *)nsevent
++{
++    NSString *chars = [nsevent charactersIgnoringModifiers];
++
++    if ([nsevent type] == NSEventTypeKeyDown && [chars length] > 0) {
++        QChar ch = [chars characterAtIndex:0];
++        Qt::Key qtKey = QAppleKeyMapper::fromCocoaKey(ch);
++        if ([nsevent modifierFlags] & NSEventModifierFlagControl
++                && (qtKey == Qt::Key_Tab || qtKey == Qt::Key_Backtab)) {
++            [self handleKeyEvent:nsevent];
++            return YES;
++        }
++    }
++    return [super performKeyEquivalent:nsevent];
++}
++
+ - (void)cancelOperation:(id)sender
+ {
+     Q_UNUSED(sender);
+diff --git a/src/widgets/kernel/qwidget.cpp b/src/widgets/kernel/qwidget.cpp
+index f56fe8559d..200d8b2a3b 100644
+--- a/src/widgets/kernel/qwidget.cpp
++++ b/src/widgets/kernel/qwidget.cpp
+@@ -8712,7 +8712,8 @@ bool QWidget::event(QEvent *event)
+     case QEvent::KeyPress: {
+         QKeyEvent *k = (QKeyEvent *)event;
+         bool res = false;
+-        if (!(k->modifiers() & (Qt::ControlModifier | Qt::AltModifier))) {  //### Add MetaModifier?
++        // Patch: Enable Ctrl+Tab and Ctrl+Shift+Tab / Ctrl+Backtab handle in-app.
++        if (!(k->modifiers() & (Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier))) {
+             if (k->key() == Qt::Key_Backtab
+                 || (k->key() == Qt::Key_Tab && (k->modifiers() & Qt::ShiftModifier)))
+                 res = focusNextPrevChild(false);

--- a/qtbase_6_3_0/0005-allow-creating-floating-panels-macos.patch
+++ b/qtbase_6_3_0/0005-allow-creating-floating-panels-macos.patch
@@ -1,0 +1,37 @@
+diff --git a/src/plugins/platforms/cocoa/qcocoawindow.mm b/src/plugins/platforms/cocoa/qcocoawindow.mm
+index 70cfa42974..2a0e44b478 100644
+--- a/src/plugins/platforms/cocoa/qcocoawindow.mm
++++ b/src/plugins/platforms/cocoa/qcocoawindow.mm
+@@ -556,6 +556,32 @@ NSUInteger QCocoaWindow::windowStyleMask(Qt::WindowFlags flags)
+         }
+     }();
+ 
++    // Patch: allow creating panels floating on all spaces in macOS.
++    // If you call "setCollectionBehavior:NSWindowCollectionBehaviorFullScreenAuxiliary" before
++    // setting the "NSWindowStyleMaskNonactivatingPanel" bit in the style mask it won't work after that.
++    // So we need a way to set that bit before Qt sets collection behavior the way it does.
++    QVariant nonactivatingPanelMask = window()->property("_td_macNonactivatingPanelMask");
++    if (nonactivatingPanelMask.isValid() && nonactivatingPanelMask.toBool()) {
++        styleMask |= NSWindowStyleMaskNonactivatingPanel;
++    }
++
++    if (frameless) {
++        // Frameless windows do not display the traffic lights buttons for
++        // e.g. minimize, however StyleMaskMiniaturizable is required to allow
++        // programmatic minimize.
++        styleMask |= NSWindowStyleMaskMiniaturizable;
++    } else if (flags & Qt::CustomizeWindowHint) {
++        if (flags & Qt::WindowTitleHint)
++            styleMask |= NSWindowStyleMaskTitled;
++        if (flags & Qt::WindowCloseButtonHint)
++            styleMask |= NSWindowStyleMaskClosable;
++        if (flags & Qt::WindowMinimizeButtonHint)
++            styleMask |= NSWindowStyleMaskMiniaturizable;
++        if (flags & Qt::WindowMaximizeButtonHint)
++            styleMask |= NSWindowStyleMaskResizable;
++    } else {
++        styleMask |= NSWindowStyleMaskClosable | NSWindowStyleMaskTitled;
++
+     // We determine which buttons to show in updateTitleBarButtons,
+     // so we can enable all the relevant style masks here to ensure
+     // that behaviors that don't involve the title bar buttons are

--- a/qtbase_6_3_0/0006-fix-file-dialog-on-windows.patch
+++ b/qtbase_6_3_0/0006-fix-file-dialog-on-windows.patch
@@ -1,0 +1,30 @@
+diff --git a/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp b/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp
+index 6fc90035ed..b34f8623bb 100644
+--- a/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp
++++ b/src/plugins/platforms/windows/qwindowsdialoghelpers.cpp
+@@ -1174,7 +1174,14 @@ void QWindowsNativeFileDialogBase::selectFile(const QString &fileName) const
+     // Hack to prevent CLSIDs from being set as file name due to
+     // QFileDialogPrivate::initialSelection() being QString-based.
+     if (!isClsid(fileName))
+-        m_fileDialog->SetFileName((wchar_t*)fileName.utf16());
++    // Patch: Fix handle of full fileName.
++    {
++        QString file = QDir::toNativeSeparators(fileName);
++        int lastBackSlash = file.lastIndexOf(QChar::fromLatin1('\\'));
++        if (lastBackSlash >= 0)
++            file = file.mid(lastBackSlash + 1);
++        m_fileDialog->SetFileName((wchar_t*)file.utf16());;
++    }
+ }
+ 
+ // Return the index of the selected filter, accounting for QFileDialog
+@@ -1449,7 +1456,8 @@ static QString createTemporaryItemCopy(QWindowsShellItem &qItem, QString *errorM
+ static QUrl itemToDialogUrl(QWindowsShellItem &qItem, QString *errorMessage)
+ {
+     QUrl url = qItem.url();
+-    if (url.isLocalFile() || url.scheme().startsWith(u"http"))
++    // Patch: Make loaded 'http' resources copy.
++    if (url.isLocalFile()/*|| url.scheme().startsWith(u"http")*/)
+         return url;
+     const QString path = qItem.path();
+     if (path.isEmpty() && !qItem.isDir() && qItem.canStream()) {

--- a/qtbase_6_3_0/0007-fix-launching-mail-program-on-windows.patch
+++ b/qtbase_6_3_0/0007-fix-launching-mail-program-on-windows.patch
@@ -1,0 +1,15 @@
+diff --git a/src/plugins/platforms/windows/qwindowsservices.cpp b/src/plugins/platforms/windows/qwindowsservices.cpp
+index 9504513a5e..811f3d62bd 100644
+--- a/src/plugins/platforms/windows/qwindowsservices.cpp
++++ b/src/plugins/platforms/windows/qwindowsservices.cpp
+@@ -125,6 +125,10 @@ static inline bool launchMail(const QUrl &url)
+             command.prepend(doubleQuote);
+         }
+     }
++
++    // Patch: Fix mail launch if no param is expected in this command.
++    if (command.indexOf(QStringLiteral("%1")) < 0) return false;
++
+     // Pass the url as the parameter. Should use QProcess::startDetached(),
+     // but that cannot handle a Windows command line [yet].
+     command.replace(QLatin1String("%1"), url.toString(QUrl::FullyEncoded));

--- a/qtbase_6_3_0/0008-fix-gtk-file-dialog-ubuntu-1404.patch
+++ b/qtbase_6_3_0/0008-fix-gtk-file-dialog-ubuntu-1404.patch
@@ -1,0 +1,22 @@
+diff --git a/src/plugins/platformthemes/gtk3/qgtk3theme.cpp b/src/plugins/platformthemes/gtk3/qgtk3theme.cpp
+index 077955eb4e..5c8a3dddf7 100644
+--- a/src/plugins/platformthemes/gtk3/qgtk3theme.cpp
++++ b/src/plugins/platformthemes/gtk3/qgtk3theme.cpp
+@@ -153,7 +153,7 @@ bool QGtk3Theme::usePlatformNativeDialog(DialogType type) const
+     case ColorDialog:
+         return true;
+     case FileDialog:
+-        return useNativeFileDialog();
++        return true;
+     case FontDialog:
+         return true;
+     default:
+@@ -167,8 +167,6 @@ QPlatformDialogHelper *QGtk3Theme::createPlatformDialogHelper(DialogType type) c
+     case ColorDialog:
+         return new QGtk3ColorDialogHelper;
+     case FileDialog:
+-        if (!useNativeFileDialog())
+-            return nullptr;
+         return new QGtk3FileDialogHelper;
+     case FontDialog:
+         return new QGtk3FontDialogHelper;

--- a/qtbase_6_3_0/0009-save-dirtyopaquechildren.patch
+++ b/qtbase_6_3_0/0009-save-dirtyopaquechildren.patch
@@ -1,0 +1,43 @@
+diff --git a/src/widgets/kernel/qwidget.cpp b/src/widgets/kernel/qwidget.cpp
+index bf339ca5c5..0981572bd9 100644
+--- a/src/widgets/kernel/qwidget.cpp
++++ b/src/widgets/kernel/qwidget.cpp
+@@ -5161,6 +5161,17 @@ void QWidget::render(QPainter *painter, const QPoint &targetOffset,
+         return; // Fully transparent.
+ 
+     Q_D(QWidget);
++
++    // Patch: save and restore dirtyOpaqueChildren field.
++    //
++    // Just like in QWidget::grab() this field should be restored
++    // after the d->render() call, because it will be set to 1 and
++    // opaqueChildren field will be filled with empty region in
++    // case the widget is hidden (because all the opaque children
++    // will be skipped in isVisible() check).
++    //
++    const bool oldDirtyOpaqueChildren = d->dirtyOpaqueChildren;
++
+     const bool inRenderWithPainter = d->extra && d->extra->inRenderWithPainter;
+     const QRegion toBePainted = !inRenderWithPainter ? d->prepareToRender(sourceRegion, renderFlags)
+                                                      : sourceRegion;
+@@ -5182,6 +5193,10 @@ void QWidget::render(QPainter *painter, const QPoint &targetOffset,
+     if (!inRenderWithPainter && (opacity < 1.0 || (target->devType() == QInternal::Printer))) {
+         d->render_helper(painter, targetOffset, toBePainted, renderFlags);
+         d->extra->inRenderWithPainter = inRenderWithPainter;
++
++        // Patch: save and restore dirtyOpaqueChildren field.
++        d->dirtyOpaqueChildren = oldDirtyOpaqueChildren;
++
+         return;
+     }
+ 
+@@ -5214,6 +5229,9 @@ void QWidget::render(QPainter *painter, const QPoint &targetOffset,
+     d->setSharedPainter(oldPainter);
+ 
+     d->extra->inRenderWithPainter = inRenderWithPainter;
++
++    // Patch: save and restore dirtyOpaqueChildren field.
++    d->dirtyOpaqueChildren = oldDirtyOpaqueChildren;
+ }
+ 
+ static void sendResizeEvents(QWidget *target)

--- a/qtbase_6_3_0/0010-count-scrollbar-sizehint-only-when-needed.patch
+++ b/qtbase_6_3_0/0010-count-scrollbar-sizehint-only-when-needed.patch
@@ -1,0 +1,23 @@
+diff --git a/src/widgets/widgets/qabstractscrollarea.cpp b/src/widgets/widgets/qabstractscrollarea.cpp
+index 720a9f908a..e7b4d3a068 100644
+--- a/src/widgets/widgets/qabstractscrollarea.cpp
++++ b/src/widgets/widgets/qabstractscrollarea.cpp
+@@ -564,15 +564,14 @@ scrolling range.
+ QSize QAbstractScrollArea::maximumViewportSize() const
+ {
+     Q_D(const QAbstractScrollArea);
+-    int hsbExt = d->hbar->sizeHint().height();
+-    int vsbExt = d->vbar->sizeHint().width();
+ 
+     int f = 2 * d->frameWidth;
+     QSize max = size() - QSize(f + d->left + d->right, f + d->top + d->bottom);
++    // Patch: Count the sizeHint of the bar only if it is displayed.
+     if (d->vbarpolicy == Qt::ScrollBarAlwaysOn)
+-        max.rwidth() -= vsbExt;
++        max.rwidth() -= d->vbar->sizeHint().width();
+     if (d->hbarpolicy == Qt::ScrollBarAlwaysOn)
+-        max.rheight() -= hsbExt;
++        max.rheight() -= d->hbar->sizeHint().height();
+     return max;
+ }
+ 

--- a/qtbase_6_3_0/0011-fix-titlebar-contextmenu-on-windows.patch
+++ b/qtbase_6_3_0/0011-fix-titlebar-contextmenu-on-windows.patch
@@ -1,0 +1,12 @@
+diff --git a/src/plugins/platforms/windows/qwindowscontext.cpp b/src/plugins/platforms/windows/qwindowscontext.cpp
+index 38b9823d6b..eaea51d001 100644
+--- a/src/plugins/platforms/windows/qwindowscontext.cpp
++++ b/src/plugins/platforms/windows/qwindowscontext.cpp
+@@ -1014,7 +1014,6 @@ static inline bool isInputMessage(UINT m)
+     case WM_NCMOUSELEAVE:
+     case WM_SIZING:
+     case WM_MOVING:
+-    case WM_SYSCOMMAND:
+     case WM_COMMAND:
+     case WM_DWMNCRENDERINGCHANGED:
+     case WM_PAINT:

--- a/qtbase_6_3_0/0012-old-freetype-compatibility.patch
+++ b/qtbase_6_3_0/0012-old-freetype-compatibility.patch
@@ -1,0 +1,55 @@
+diff --git a/src/gui/text/freetype/qfontengine_ft.cpp b/src/gui/text/freetype/qfontengine_ft.cpp
+index c494c77e95..6a2f95e71c 100644
+--- a/src/gui/text/freetype/qfontengine_ft.cpp
++++ b/src/gui/text/freetype/qfontengine_ft.cpp
+@@ -59,6 +59,10 @@
+ #include <qmath.h>
+ #include <qendian.h>
+ 
++#if QT_CONFIG(system_freetype) && QT_CONFIG(dlopen)
++#include <dlfcn.h>
++#endif
++
+ #include <memory>
+ 
+ #include <ft2build.h>
+@@ -94,6 +98,8 @@ QT_BEGIN_NAMESPACE
+ #define TRUNC(x)    ((x) >> 6)
+ #define ROUND(x)    (((x)+32) & -64)
+ 
++const char *(*ptrFT_Get_Font_Format)(FT_Face face) = nullptr;
++
+ static bool ft_getSfntTable(void *user_data, uint tag, uchar *buffer, uint *length)
+ {
+     FT_Face face = (FT_Face)user_data;
+@@ -151,9 +157,18 @@ QtFreetypeData *qt_getFreetypeData()
+     if (!freetypeData->library) {
+         FT_Init_FreeType(&freetypeData->library);
+ #if defined(FT_FONT_FORMATS_H)
+-        // Freetype defaults to disabling stem-darkening on CFF, we re-enable it.
+-        FT_Bool no_darkening = false;
+-        FT_Property_Set(freetypeData->library, "cff", "no-stem-darkening", &no_darkening);
++#if QT_CONFIG(system_freetype) && QT_CONFIG(dlopen)
++        ptrFT_Get_Font_Format = reinterpret_cast<decltype(ptrFT_Get_Font_Format)>(dlsym(
++            RTLD_DEFAULT,
++            "FT_Get_Font_Format"));
++#else
++        ptrFT_Get_Font_Format = FT_Get_Font_Format;
++#endif
++        if (ptrFT_Get_Font_Format) {
++            // Freetype defaults to disabling stem-darkening on CFF, we re-enable it.
++            FT_Bool no_darkening = false;
++            FT_Property_Set(freetypeData->library, "cff", "no-stem-darkening", &no_darkening);
++        }
+ #endif
+     }
+     return freetypeData;
+@@ -813,7 +828,7 @@ bool QFontEngineFT::init(FaceId faceId, bool antialias, GlyphFormat format,
+         }
+     }
+ #if defined(FT_FONT_FORMATS_H)
+-    const char *fmt = FT_Get_Font_Format(face);
++    const char *fmt = ptrFT_Get_Font_Format ? ptrFT_Get_Font_Format(face) : nullptr;
+     if (fmt && qstrncmp(fmt, "CFF", 4) == 0) {
+         FT_Bool no_stem_darkening = true;
+         FT_Error err = FT_Property_Get(qt_getFreetype(), "cff", "no-stem-darkening", &no_stem_darkening);

--- a/qtbase_6_3_0/0013-nice-osx-tray-icon.patch
+++ b/qtbase_6_3_0/0013-nice-osx-tray-icon.patch
@@ -1,0 +1,226 @@
+diff --git a/src/plugins/platforms/cocoa/qcocoasystemtrayicon.h b/src/plugins/platforms/cocoa/qcocoasystemtrayicon.h
+index ddc76f6b72..fe72340e20 100644
+--- a/src/plugins/platforms/cocoa/qcocoasystemtrayicon.h
++++ b/src/plugins/platforms/cocoa/qcocoasystemtrayicon.h
+@@ -82,11 +82,14 @@ public:
+     bool supportsMessages() const override;
+ 
+     void statusItemClicked();
++    void updateItemIcon();
+ 
+ private:
+     NSStatusItem *m_statusItem = nullptr;
+     QStatusItemDelegate *m_delegate = nullptr;
+     QCocoaMenu *m_menu = nullptr;
++    QIcon m_icon;
++    bool m_handledOnPress = false;
+ };
+ 
+ QT_END_NAMESPACE
+diff --git a/src/plugins/platforms/cocoa/qcocoasystemtrayicon.mm b/src/plugins/platforms/cocoa/qcocoasystemtrayicon.mm
+index 962d1e34b3..86e20c3696 100644
+--- a/src/plugins/platforms/cocoa/qcocoasystemtrayicon.mm
++++ b/src/plugins/platforms/cocoa/qcocoasystemtrayicon.mm
+@@ -102,7 +102,8 @@ void QCocoaSystemTrayIcon::init()
+ 
+     m_statusItem.button.target = m_delegate;
+     m_statusItem.button.action = @selector(statusItemClicked);
+-    [m_statusItem.button sendActionOn:NSEventMaskLeftMouseDown | NSEventMaskRightMouseDown | NSEventMaskOtherMouseDown];
++    [m_statusItem.button sendActionOn:NSEventMaskLeftMouseDown | NSEventMaskLeftMouseUp | NSEventMaskRightMouseUp | NSEventMaskOtherMouseUp];
++    [m_statusItem addObserver:m_delegate forKeyPath:@"button.effectiveAppearance" options:NSKeyValueObservingOptionNew|NSKeyValueObservingOptionInitial context:nil];
+ }
+ 
+ void QCocoaSystemTrayIcon::cleanup()
+@@ -111,6 +112,8 @@ void QCocoaSystemTrayIcon::cleanup()
+     if (center.delegate == m_delegate)
+         center.delegate = nil;
+ 
++    [m_statusItem removeObserver:m_delegate forKeyPath:@"button.effectiveAppearance"];
++
+     [NSStatusBar.systemStatusBar removeStatusItem:m_statusItem];
+     [m_statusItem release];
+     m_statusItem = nil;
+@@ -143,15 +146,26 @@ static QList<QSize> sortByHeight(const QList<QSize> &sizes)
+ }
+ 
+ void QCocoaSystemTrayIcon::updateIcon(const QIcon &icon)
++{
++    m_icon = icon;
++    updateItemIcon();
++}
++
++void QCocoaSystemTrayIcon::updateItemIcon()
+ {
+     if (!m_statusItem)
+         return;
+ 
++    NSAppearance *appearance = m_statusItem.button.effectiveAppearance;
++    NSString *appearanceName = (NSString*)(appearance.name);
++    const auto darkMode = [[appearanceName lowercaseString] containsString:@"dark"];
++    const auto state = darkMode ? QIcon::On : QIcon::Off;
++
+     // The recommended maximum title bar icon height is 18 points
+     // (device independent pixels). The menu height on past and
+     // current OS X versions is 22 points. Provide some future-proofing
+     // by deriving the icon height from the menu height.
+-    const int padding = 4;
++    const int padding = 0;
+     const int menuHeight = NSStatusBar.systemStatusBar.thickness;
+     const int maxImageHeight = menuHeight - padding;
+ 
+@@ -161,54 +175,60 @@ void QCocoaSystemTrayIcon::updateIcon(const QIcon &icon)
+     // devicePixelRatio for the "best" screen on the system.
+     qreal devicePixelRatio = qApp->devicePixelRatio();
+     const int maxPixmapHeight = maxImageHeight * devicePixelRatio;
+-    QSize selectedSize;
+-    for (const QSize& size : sortByHeight(icon.availableSizes())) {
+-        // Select a pixmap based on the height. We want the largest pixmap
+-        // with a height smaller or equal to maxPixmapHeight. The pixmap
+-        // may rectangular; assume it has a reasonable size. If there is
+-        // not suitable pixmap use the smallest one the icon can provide.
+-        if (size.height() <= maxPixmapHeight) {
+-            selectedSize = size;
+-        } else {
+-            if (!selectedSize.isValid())
++
++    const auto imageByMode = [&](QIcon::Mode mode) {
++        QSize selectedSize;
++        for (const QSize& size : sortByHeight(m_icon.availableSizes(mode, state))) {
++            // Select a pixmap based on the height. We want the largest pixmap
++            // with a height smaller or equal to maxPixmapHeight. The pixmap
++            // may rectangular; assume it has a reasonable size. If there is
++            // not suitable pixmap use the smallest one the icon can provide.
++            if (size.height() <= maxPixmapHeight) {
+                 selectedSize = size;
+-            break;
++            } else {
++                if (!selectedSize.isValid())
++                    selectedSize = size;
++                break;
++            }
+         }
+-    }
+ 
+-    // Handle SVG icons, which do not return anything for availableSizes().
+-    if (!selectedSize.isValid())
+-        selectedSize = icon.actualSize(QSize(maxPixmapHeight, maxPixmapHeight));
+-
+-    QPixmap pixmap = icon.pixmap(selectedSize);
+-
+-    // Draw a low-resolution icon if there is not enough pixels for a retina
+-    // icon. This prevents showing a small icon on retina displays.
+-    if (devicePixelRatio > 1.0 && selectedSize.height() < maxPixmapHeight / 2)
+-        devicePixelRatio = 1.0;
+-
+-    // Scale large pixmaps to fit the available menu bar area.
+-    if (pixmap.height() > maxPixmapHeight)
+-        pixmap = pixmap.scaledToHeight(maxPixmapHeight, Qt::SmoothTransformation);
+-
+-    // The icon will be stretched over the full height of the menu bar
+-    // therefore we create a second pixmap which has the full height
+-    QSize fullHeightSize(!pixmap.isNull() ? pixmap.width():
+-                                            menuHeight * devicePixelRatio,
+-                         menuHeight * devicePixelRatio);
+-    QPixmap fullHeightPixmap(fullHeightSize);
+-    fullHeightPixmap.fill(Qt::transparent);
+-    if (!pixmap.isNull()) {
+-        QPainter p(&fullHeightPixmap);
+-        QRect r = pixmap.rect();
+-        r.moveCenter(fullHeightPixmap.rect().center());
+-        p.drawPixmap(r, pixmap);
+-    }
+-    fullHeightPixmap.setDevicePixelRatio(devicePixelRatio);
+-
+-    auto *nsimage = [NSImage imageFromQImage:fullHeightPixmap.toImage()];
+-    [nsimage setTemplate:icon.isMask()];
+-    m_statusItem.button.image = nsimage;
++        // Handle SVG icons, which do not return anything for availableSizes().
++        if (!selectedSize.isValid())
++            selectedSize = m_icon.actualSize(QSize(maxPixmapHeight, maxPixmapHeight), mode, state);
++
++        QPixmap pixmap = m_icon.pixmap(selectedSize, mode, state);
++
++        // Draw a low-resolution icon if there is not enough pixels for a retina
++        // icon. This prevents showing a small icon on retina displays.
++        if (devicePixelRatio > 1.0 && selectedSize.height() < maxPixmapHeight / 2)
++            devicePixelRatio = 1.0;
++
++        // Scale large pixmaps to fit the available menu bar area.
++        if (pixmap.height() > maxPixmapHeight)
++            pixmap = pixmap.scaledToHeight(maxPixmapHeight, Qt::SmoothTransformation);
++
++        // The icon will be stretched over the full height of the menu bar
++        // therefore we create a second pixmap which has the full height
++        // QSize fullHeightSize(!pixmap.isNull() ? pixmap.width():
++        //                                         menuHeight * devicePixelRatio,
++        //                      menuHeight * devicePixelRatio);
++        // QPixmap fullHeightPixmap(fullHeightSize);
++        // fullHeightPixmap.fill(Qt::transparent);
++        // if (!pixmap.isNull()) {
++        //     QPainter p(&fullHeightPixmap);
++        //     QRect r = pixmap.rect();
++        //     r.moveCenter(fullHeightPixmap.rect().center());
++        //     p.drawPixmap(r, pixmap);
++        // }
++        // fullHeightPixmap.setDevicePixelRatio(devicePixelRatio);
++
++        auto *nsimage = [NSImage imageFromQImage:pixmap.toImage()];
++        [nsimage setTemplate:m_icon.isMask()];
++
++        return nsimage;
++    };
++    m_statusItem.button.image = imageByMode(QIcon::Normal);
++    m_statusItem.button.alternateImage = imageByMode(QIcon::Active);
+     m_statusItem.button.imageScaling = NSImageScaleProportionallyDown;
+ }
+ 
+@@ -266,6 +286,18 @@ void QCocoaSystemTrayIcon::statusItemClicked()
+ {
+     auto *mouseEvent = NSApp.currentEvent;
+ 
++	if (mouseEvent.type == NSEventTypeLeftMouseDown) {
++		m_handledOnPress = !m_menu;
++		if (!m_handledOnPress) {
++			return;
++		}
++		[m_statusItem.button highlight:NO];
++	} else if (mouseEvent.type == NSEventTypeLeftMouseUp) {
++		if (m_handledOnPress) {
++			return;
++		}
++	}
++
+     auto activationReason = QPlatformSystemTrayIcon::Unknown;
+ 
+     if (mouseEvent.clickCount == 2) {
+@@ -322,6 +354,14 @@ QT_END_NAMESPACE
+     emit self.platformSystemTray->messageClicked();
+ }
+ 
++// Thanks https://stackoverflow.com/a/64525038
++-(void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context
++{
++    if ([keyPath isEqualToString:@"button.effectiveAppearance"]) {
++        self.platformSystemTray->updateItemIcon();
++    }
++}
++
+ @end
+ 
+ #endif // QT_NO_SYSTEMTRAYICON
+diff --git a/src/widgets/util/qsystemtrayicon_qpa.cpp b/src/widgets/util/qsystemtrayicon_qpa.cpp
+index 9694e0a6b3..401c61bbf9 100644
+--- a/src/widgets/util/qsystemtrayicon_qpa.cpp
++++ b/src/widgets/util/qsystemtrayicon_qpa.cpp
+@@ -98,6 +98,11 @@ void QSystemTrayIconPrivate::updateMenu_sys()
+     if (qpa_sys && menu) {
+         addPlatformMenu(menu);
+         qpa_sys->updateMenu(menu->platformMenu());
++
++    // Patch: Create a rich os x tray icon (pixel-perfect, theme switching).
++    } else if (qpa_sys) {
++        qpa_sys->updateMenu(nullptr);
++
+     }
+ #endif
+ }

--- a/qtbase_6_3_0/0014-always-use-xft-font-conf.patch
+++ b/qtbase_6_3_0/0014-always-use-xft-font-conf.patch
@@ -1,0 +1,144 @@
+diff --git a/src/gui/text/unix/qfontconfigdatabase.cpp b/src/gui/text/unix/qfontconfigdatabase.cpp
+index ee9d323747..b79b0b740f 100644
+--- a/src/gui/text/unix/qfontconfigdatabase.cpp
++++ b/src/gui/text/unix/qfontconfigdatabase.cpp
+@@ -48,8 +48,6 @@
+ 
+ #include <qpa/qplatformnativeinterface.h>
+ #include <qpa/qplatformscreen.h>
+-#include <qpa/qplatformintegration.h>
+-#include <qpa/qplatformservices.h>
+ 
+ #include <QtGui/private/qguiapplication_p.h>
+ #include <QtGui/private/qhighdpiscaling_p.h>
+@@ -640,7 +638,15 @@ QFontEngineMulti *QFontconfigDatabase::fontEngineMulti(QFontEngine *fontEngine,
+ }
+ 
+ namespace {
+-QFontEngine::HintStyle defaultHintStyleFromMatch(QFont::HintingPreference hintingPreference, FcPattern *match, bool useXftConf)
++template<typename T>
++inline T fromPlatformNativeResource(int nativeValue)
++{
++    // native resource returns nullptr at fail,
++    // so successful values are returned with + 1
++    return static_cast<T>(nativeValue - 1);
++}
++
++QFontEngine::HintStyle defaultHintStyleFromMatch(QFont::HintingPreference hintingPreference, FcPattern *match)
+ {
+     switch (hintingPreference) {
+     case QFont::PreferNoHinting:
+@@ -656,9 +662,15 @@ QFontEngine::HintStyle defaultHintStyleFromMatch(QFont::HintingPreference hintin
+     if (QHighDpiScaling::isActive())
+         return QFontEngine::HintNone;
+ 
+-    int hint_style = 0;
+-    if (FcPatternGetInteger (match, FC_HINT_STYLE, 0, &hint_style) == FcResultMatch) {
+-        switch (hint_style) {
++    void *hintStyleResource =
++            QGuiApplication::platformNativeInterface()->nativeResourceForScreen("hintstyle",
++                                                                                QGuiApplication::primaryScreen());
++    int hintStyle = int(reinterpret_cast<qintptr>(hintStyleResource));
++    if (hintStyle > 0)
++        return fromPlatformNativeResource<QFontEngine::HintStyle>(hintStyle);
++
++    if (FcPatternGetInteger (match, FC_HINT_STYLE, 0, &hintStyle) == FcResultMatch) {
++        switch (hintStyle) {
+         case FC_HINT_NONE:
+             return QFontEngine::HintNone;
+         case FC_HINT_SLIGHT:
+@@ -673,23 +685,20 @@ QFontEngine::HintStyle defaultHintStyleFromMatch(QFont::HintingPreference hintin
+         }
+     }
+ 
+-    if (useXftConf) {
+-        void *hintStyleResource =
+-                QGuiApplication::platformNativeInterface()->nativeResourceForScreen("hintstyle",
+-                                                                                    QGuiApplication::primaryScreen());
+-        int hintStyle = int(reinterpret_cast<qintptr>(hintStyleResource));
+-        if (hintStyle > 0)
+-            return QFontEngine::HintStyle(hintStyle - 1);
+-    }
+-
+     return QFontEngine::HintFull;
+ }
+ 
+-QFontEngine::SubpixelAntialiasingType subpixelTypeFromMatch(FcPattern *match, bool useXftConf)
++QFontEngine::SubpixelAntialiasingType subpixelTypeFromMatch(FcPattern *match)
+ {
+-    int subpixel = FC_RGBA_UNKNOWN;
+-    if (FcPatternGetInteger(match, FC_RGBA, 0, &subpixel) == FcResultMatch) {
+-        switch (subpixel) {
++    void *subpixelTypeResource =
++            QGuiApplication::platformNativeInterface()->nativeResourceForScreen("subpixeltype",
++                                                                                QGuiApplication::primaryScreen());
++    int subpixelType = int(reinterpret_cast<qintptr>(subpixelTypeResource));
++    if (subpixelType > 0)
++        return fromPlatformNativeResource<QFontEngine::SubpixelAntialiasingType>(subpixelType);
++
++    if (FcPatternGetInteger(match, FC_RGBA, 0, &subpixelType) == FcResultMatch) {
++        switch (subpixelType) {
+         case FC_RGBA_UNKNOWN:
+         case FC_RGBA_NONE:
+             return QFontEngine::Subpixel_None;
+@@ -707,15 +716,6 @@ QFontEngine::SubpixelAntialiasingType subpixelTypeFromMatch(FcPattern *match, bo
+         }
+     }
+ 
+-    if (useXftConf) {
+-        void *subpixelTypeResource =
+-                QGuiApplication::platformNativeInterface()->nativeResourceForScreen("subpixeltype",
+-                                                                                    QGuiApplication::primaryScreen());
+-        int subpixelType = int(reinterpret_cast<qintptr>(subpixelTypeResource));
+-        if (subpixelType > 0)
+-            return QFontEngine::SubpixelAntialiasingType(subpixelType - 1);
+-    }
+-
+     return QFontEngine::Subpixel_None;
+ }
+ } // namespace
+@@ -954,21 +954,15 @@ void QFontconfigDatabase::setupFontEngine(QFontEngineFT *engine, const QFontDef
+     bool antialias = !(fontDef.styleStrategy & QFont::NoAntialias);
+     bool forcedAntialiasSetting = !antialias || QHighDpiScaling::isActive();
+ 
+-    const QPlatformServices *services = QGuiApplicationPrivate::platformIntegration()->services();
+-    bool useXftConf = false;
+-
+-    if (services) {
+-        const QList<QByteArray> desktopEnv = services->desktopEnvironment().split(':');
+-        useXftConf = desktopEnv.contains("GNOME") || desktopEnv.contains("UNITY") || desktopEnv.contains("XFCE");
+-    }
+-
+-    if (useXftConf && !forcedAntialiasSetting) {
++    if (!forcedAntialiasSetting) {
+         void *antialiasResource =
+                 QGuiApplication::platformNativeInterface()->nativeResourceForScreen("antialiasingEnabled",
+                                                                                     QGuiApplication::primaryScreen());
+         int antialiasingEnabled = int(reinterpret_cast<qintptr>(antialiasResource));
+-        if (antialiasingEnabled > 0)
+-            antialias = antialiasingEnabled - 1;
++        if (antialiasingEnabled > 0) {
++            antialias = fromPlatformNativeResource<bool>(antialiasingEnabled);
++            forcedAntialiasSetting = true;
++        }
+     }
+ 
+     QFontEngine::GlyphFormat format;
+@@ -1002,7 +996,7 @@ void QFontconfigDatabase::setupFontEngine(QFontEngineFT *engine, const QFontDef
+ 
+     FcPattern *match = FcFontMatch(nullptr, pattern, &result);
+     if (match) {
+-        engine->setDefaultHintStyle(defaultHintStyleFromMatch((QFont::HintingPreference)fontDef.hintingPreference, match, useXftConf));
++        engine->setDefaultHintStyle(defaultHintStyleFromMatch((QFont::HintingPreference)fontDef.hintingPreference, match));
+ 
+         FcBool fc_autohint;
+         if (FcPatternGetBool(match, FC_AUTOHINT,0, &fc_autohint) == FcResultMatch)
+@@ -1023,7 +1017,7 @@ void QFontconfigDatabase::setupFontEngine(QFontEngineFT *engine, const QFontDef
+         if (antialias) {
+             QFontEngine::SubpixelAntialiasingType subpixelType = QFontEngine::Subpixel_None;
+             if (!(fontDef.styleStrategy & QFont::NoSubpixelAntialias))
+-                subpixelType = subpixelTypeFromMatch(match, useXftConf);
++                subpixelType = subpixelTypeFromMatch(match);
+             engine->subpixelType = subpixelType;
+ 
+             format = (subpixelType == QFontEngine::Subpixel_None)

--- a/qtbase_6_3_0/0015-catch-cocoa-dock-menu.patch
+++ b/qtbase_6_3_0/0015-catch-cocoa-dock-menu.patch
@@ -1,0 +1,18 @@
+diff --git a/src/plugins/platforms/cocoa/qcocoaapplicationdelegate.mm b/src/plugins/platforms/cocoa/qcocoaapplicationdelegate.mm
+index e8d789275c..9981588219 100644
+--- a/src/plugins/platforms/cocoa/qcocoaapplicationdelegate.mm
++++ b/src/plugins/platforms/cocoa/qcocoaapplicationdelegate.mm
+@@ -138,7 +138,12 @@ QT_USE_NAMESPACE
+ 
+ - (NSMenu *)applicationDockMenu:(NSApplication *)sender
+ {
+-    Q_UNUSED(sender);
++    // Patch: We need to catch that event in delegate.
++    if (reflectionDelegate
++        && [reflectionDelegate respondsToSelector:@selector(applicationDockMenu:)]) {
++        return [reflectionDelegate applicationDockMenu:sender];
++    }
++
+     // Manually invoke the delegate's -menuWillOpen: method.
+     // See QTBUG-39604 (and its fix) for details.
+     [self.dockMenu.delegate menuWillOpen:self.dockMenu];

--- a/qtbase_6_3_0/0016-fix-race-in-windows-timers.patch
+++ b/qtbase_6_3_0/0016-fix-race-in-windows-timers.patch
@@ -1,0 +1,139 @@
+diff --git a/src/corelib/kernel/qeventdispatcher_win.cpp b/src/corelib/kernel/qeventdispatcher_win.cpp
+index 97e3cbdb04..d5dc2cbe3d 100644
+--- a/src/corelib/kernel/qeventdispatcher_win.cpp
++++ b/src/corelib/kernel/qeventdispatcher_win.cpp
+@@ -114,7 +114,17 @@ void WINAPI QT_WIN_CALLBACK qt_fast_timer_proc(uint timerId, uint /*reserved*/,
+         return;
+     auto t = reinterpret_cast<WinTimerInfo*>(user);
+     Q_ASSERT(t);
+-    QCoreApplication::postEvent(t->dispatcher, new QTimerEvent(t->timerId));
++    QMutexLocker lock(&t->fastTimerMutex);
++    if (t->timerId != -1) {
++        QCoreApplication::postEvent(t->dispatcher, new QTimerEvent(t->timerId));
++        return;
++    }
++    Q_ASSERT(!t->inTimerEvent);
++    Q_ASSERT(t->fastTimerId != 0);
++    timeKillEvent(t->fastTimerId);
++    lock.unlock();
++
++    delete t;
+ }
+ 
+ LRESULT QT_WIN_CALLBACK qt_internal_proc(HWND hwnd, UINT message, WPARAM wp, LPARAM lp)
+@@ -358,12 +368,12 @@ void QEventDispatcherWin32Private::registerTimer(WinTimerInfo *t)
+         // optimization for single-shot-zero-timer
+         QCoreApplication::postEvent(q, new QZeroTimerEvent(t->timerId));
+         ok = true;
+-    } else if (interval < 20u || t->timerType == Qt::PreciseTimer) {
++    } else if (interval < 20u || (interval < 1000u && t->timerType == Qt::PreciseTimer)) {
+         // 3/2016: Although MSDN states timeSetEvent() is deprecated, the function
+         // is still deemed to be the most reliable precision timer.
+         t->fastTimerId = timeSetEvent(interval, 1, qt_fast_timer_proc, DWORD_PTR(t),
+                                       TIME_CALLBACK_FUNCTION | TIME_PERIODIC | TIME_KILL_SYNCHRONOUS);
+-        ok = t->fastTimerId;
++        ok = (t->fastTimerId != 0);
+     }
+ 
+     if (!ok) {
+@@ -377,16 +387,34 @@ void QEventDispatcherWin32Private::registerTimer(WinTimerInfo *t)
+ 
+ void QEventDispatcherWin32Private::unregisterTimer(WinTimerInfo *t)
+ {
++    const auto tTimerId = t->timerId;
++    const auto tDispatcher = t->dispatcher;
++    const auto tUseFastTimer = (t->fastTimerId != 0);
++    const auto tDelete = (!tUseFastTimer && !t->inTimerEvent);
+     if (t->interval == 0) {
+-        QCoreApplicationPrivate::removePostedTimerEvent(t->dispatcher, t->timerId);
+-    } else if (t->fastTimerId != 0) {
+-        timeKillEvent(t->fastTimerId);
+-        QCoreApplicationPrivate::removePostedTimerEvent(t->dispatcher, t->timerId);
++        QCoreApplicationPrivate::removePostedTimerEvent(tDispatcher, tTimerId);
++    } else if (tUseFastTimer) {
++        // 't' will be deleted in the next qt_fast_timer_proc.
++        // timeKillEvent(t->fastTimerId);
+     } else {
+-        KillTimer(internalHwnd, t->timerId);
++        KillTimer(internalHwnd, tTimerId);
++    }
++    if (tUseFastTimer && !t->inTimerEvent) {
++        // sendTimerEvent locks the mutex in case of t->inTimerEvent.
++        t->fastTimerMutex.lock();
+     }
++    // Upon fastTimerMutex unlock qt_fast_timer_proc may delete 't'.
+     t->timerId = -1;
+-    if (!t->inTimerEvent)
++    if (tUseFastTimer) {
++        if (!t->inTimerEvent) {
++            // sendTimerEvent unlocks the mutex in case of t->inTimerEvent.
++            // Right after that line qt_fast_timer_proc may delete 't'.
++            t->fastTimerMutex.unlock();
++        }
++        QCoreApplicationPrivate::removePostedTimerEvent(tDispatcher, tTimerId);
++    }
++
++    if (tDelete)
+         delete t;
+ }
+ 
+@@ -401,14 +429,27 @@ void QEventDispatcherWin32Private::sendTimerEvent(int timerId)
+         calculateNextTimeout(t, qt_msectime());
+ 
+         QTimerEvent e(t->timerId);
++
++        const auto tUseFastTimer = (t->fastTimerId != 0);
++        if (tUseFastTimer) {
++            // sendEvent below may unregisterTimer,
++            // qt_fast_timer_proc should not delete 't' just yet.
++            t->fastTimerMutex.lock();
++        }
++
+         QCoreApplication::sendEvent(t->obj, &e);
+ 
+         // timer could have been removed
+-        if (t->timerId == -1) {
++        if (t->timerId == -1 && !tUseFastTimer) {
+             delete t;
+         } else {
+             t->inTimerEvent = false;
+         }
++
++        if (tUseFastTimer) {
++            // Right after that line qt_fast_timer_proc may delete 't'.
++            t->fastTimerMutex.unlock();
++        }
+     }
+ }
+ 
+@@ -868,7 +909,9 @@ bool QEventDispatcherWin32::event(QEvent *e)
+ 
+             // timer could have been removed
+             if (t->timerId == -1) {
+-                delete t;
++                if (t->fastTimerId == 0) {
++                    delete t;
++                }
+             } else {
+                 if (t->interval == 0 && t->inTimerEvent) {
+                     // post the next zero timer event as long as the timer was not restarted
+diff --git a/src/corelib/kernel/qeventdispatcher_win_p.h b/src/corelib/kernel/qeventdispatcher_win_p.h
+index 49a6d3ebbc..beefde6cd6 100644
+--- a/src/corelib/kernel/qeventdispatcher_win_p.h
++++ b/src/corelib/kernel/qeventdispatcher_win_p.h
+@@ -55,6 +55,7 @@
+ #include "QtCore/qt_windows.h"
+ #include "QtCore/qhash.h"
+ #include "QtCore/qatomic.h"
++#include "QtCore/qmutex.h"
+ 
+ #include "qabstracteventdispatcher_p.h"
+ 
+@@ -130,6 +131,7 @@ struct WinTimerInfo {                           // internal timer info
+     QObject *obj;                               // - object to receive events
+     bool inTimerEvent;
+     UINT fastTimerId;
++    QMutex fastTimerMutex;
+ };
+ 
+ class QZeroTimerEvent : public QTimerEvent

--- a/qtbase_6_3_0/0017-handle-amd_switchable-in-gpu-bugs-list.patch
+++ b/qtbase_6_3_0/0017-handle-amd_switchable-in-gpu-bugs-list.patch
@@ -1,0 +1,120 @@
+diff --git a/src/gui/opengl/qopengl.cpp b/src/gui/opengl/qopengl.cpp
+index 3066b83282..cc5947b4f6 100644
+--- a/src/gui/opengl/qopengl.cpp
++++ b/src/gui/opengl/qopengl.cpp
+@@ -389,6 +389,12 @@ static bool matches(const QJsonObject &object,
+         }
+     }
+ 
++    if (object.value(QLatin1String("multi_gpu_style")).toString() == QLatin1String("amd_switchable")) {
++        if (!gpu.amdSwitchable) {
++            return false;
++        }
++    }
++
+     return true;
+ }
+ 
+diff --git a/src/gui/opengl/qopengl_p.h b/src/gui/opengl/qopengl_p.h
+index 07fd159ba8..1490a7e2d6 100644
+--- a/src/gui/opengl/qopengl_p.h
++++ b/src/gui/opengl/qopengl_p.h
+@@ -95,6 +95,8 @@ public:
+         QByteArray driverDescription;
+         QByteArray glVendor;
+ 
++        bool amdSwitchable = false;
++
+         static Gpu fromDevice(uint vendorId, uint deviceId, QVersionNumber driverVersion, const QByteArray &driverDescription) {
+             Gpu gpu;
+             gpu.vendorId = vendorId;
+diff --git a/src/plugins/platforms/windows/qwindowsopengltester.cpp b/src/plugins/platforms/windows/qwindowsopengltester.cpp
+index 0b1af47a65..b75c34be62 100644
+--- a/src/plugins/platforms/windows/qwindowsopengltester.cpp
++++ b/src/plugins/platforms/windows/qwindowsopengltester.cpp
+@@ -61,6 +61,7 @@
+ QT_BEGIN_NAMESPACE
+ 
+ static const DWORD VENDOR_ID_AMD = 0x1002;
++static const DWORD VENDOR_ID_INTEL = 0x8086;
+ 
+ static GpuDescription adapterIdentifierToGpuDescription(const D3DADAPTER_IDENTIFIER9 &adapterIdentifier)
+ {
+@@ -141,31 +142,42 @@ GpuDescription GpuDescription::detect()
+         isAMD = result.vendorId == VENDOR_ID_AMD;
+     }
+ 
++    bool isIntel = (result.vendorId == VENDOR_ID_INTEL);
++    bool hasAMD = isAMD;
++    bool hasIntel = isIntel;
++
+     // Detect QTBUG-50371 (having AMD as the default adapter results in a crash
+     // when starting apps on a screen connected to the Intel card) by looking
+     // for a default AMD adapter and an additional non-AMD one.
+-    if (isAMD) {
++	if (true || isAMD) {
+         const UINT adapterCount = direct3D9.adapterCount();
+         for (UINT adp = 1; adp < adapterCount; ++adp) {
+-            if (direct3D9.retrieveAdapterIdentifier(adp, &adapterIdentifier)
+-                && adapterIdentifier.VendorId != VENDOR_ID_AMD) {
+-                // Bingo. Now figure out the display for the AMD card.
+-                DISPLAY_DEVICE dd;
+-                memset(&dd, 0, sizeof(dd));
+-                dd.cb = sizeof(dd);
+-                for (int dev = 0; EnumDisplayDevices(nullptr, dev, &dd, 0); ++dev) {
+-                    if (dd.StateFlags & DISPLAY_DEVICE_PRIMARY_DEVICE) {
+-                        // DeviceName is something like \\.\DISPLAY1 which can be used to
+-                        // match with the MONITORINFOEX::szDevice queried by QWindowsScreen.
+-                        result.gpuSuitableScreen = QString::fromWCharArray(dd.DeviceName);
+-                        break;
++            if (direct3D9.retrieveAdapterIdentifier(adp, &adapterIdentifier)) {
++                if (isAMD && adapterIdentifier.VendorId != VENDOR_ID_AMD) {
++                    // Bingo. Now figure out the display for the AMD card.
++                    DISPLAY_DEVICE dd;
++                    memset(&dd, 0, sizeof(dd));
++                    dd.cb = sizeof(dd);
++                    for (int dev = 0; EnumDisplayDevices(nullptr, dev, &dd, 0); ++dev) {
++                        if (dd.StateFlags & DISPLAY_DEVICE_PRIMARY_DEVICE) {
++                            // DeviceName is something like \\.\DISPLAY1 which can be used to
++                            // match with the MONITORINFOEX::szDevice queried by QWindowsScreen.
++                            result.gpuSuitableScreen = QString::fromWCharArray(dd.DeviceName);
++                            break;
++                        }
+                     }
+                 }
+-                break;
++                if (adapterIdentifier.VendorId == VENDOR_ID_AMD) {
++                    hasAMD = true;
++                } else if (adapterIdentifier.VendorId == VENDOR_ID_INTEL) {
++                    hasIntel = true;
++                }
+             }
+         }
+     }
+ 
++    result.amdSwitchable = hasAMD && hasIntel;
++
+     return result;
+ }
+ 
+@@ -286,6 +298,7 @@ QWindowsOpenGLTester::Renderers QWindowsOpenGLTester::detectSupportedRenderers(c
+     return {};
+ #else
+     QOpenGLConfig::Gpu qgpu = QOpenGLConfig::Gpu::fromDevice(gpu.vendorId, gpu.deviceId, gpu.driverVersion, gpu.description);
++    qgpu.amdSwitchable = gpu.amdSwitchable;
+     SupportedRenderersCache *srCache = supportedRenderersCache();
+     SupportedRenderersCache::const_iterator it = srCache->constFind(qgpu);
+     if (it != srCache->cend())
+diff --git a/src/plugins/platforms/windows/qwindowsopengltester.h b/src/plugins/platforms/windows/qwindowsopengltester.h
+index 9091949699..e106ab87d2 100644
+--- a/src/plugins/platforms/windows/qwindowsopengltester.h
++++ b/src/plugins/platforms/windows/qwindowsopengltester.h
+@@ -65,6 +65,8 @@ struct GpuDescription
+     QByteArray driverName;
+     QByteArray description;
+     QString gpuSuitableScreen;
++
++    bool amdSwitchable = false;
+ };
+ 
+ #ifndef QT_NO_DEBUG_STREAM

--- a/qtbase_6_3_0/0018-gtk-as-last-resort.patch
+++ b/qtbase_6_3_0/0018-gtk-as-last-resort.patch
@@ -1,0 +1,42 @@
+diff --git a/src/gui/platform/unix/qgenericunixthemes.cpp b/src/gui/platform/unix/qgenericunixthemes.cpp
+index 86f2a266ea..49be369452 100644
+--- a/src/gui/platform/unix/qgenericunixthemes.cpp
++++ b/src/gui/platform/unix/qgenericunixthemes.cpp
+@@ -853,24 +853,12 @@ QStringList QGenericUnixTheme::themeNames()
+     QStringList result;
+     if (QGuiApplication::desktopSettingsAware()) {
+         const QByteArray desktopEnvironment = QGuiApplicationPrivate::platformIntegration()->services()->desktopEnvironment();
+-        QList<QByteArray> gtkBasedEnvironments;
+-        gtkBasedEnvironments << "GNOME"
+-                             << "X-CINNAMON"
+-                             << "UNITY"
+-                             << "MATE"
+-                             << "XFCE"
+-                             << "LXDE";
+         const QList<QByteArray> desktopNames = desktopEnvironment.split(':');
+         for (const QByteArray &desktopName : desktopNames) {
+             if (desktopEnvironment == "KDE") {
+ #if QT_CONFIG(settings)
+                 result.push_back(QLatin1String(QKdeTheme::name));
+ #endif
+-            } else if (gtkBasedEnvironments.contains(desktopName)) {
+-                // prefer the GTK3 theme implementation with native dialogs etc.
+-                result.push_back(QStringLiteral("gtk3"));
+-                // fallback to the generic Gnome theme if loading the GTK3 theme fails
+-                result.push_back(QLatin1String(QGnomeTheme::name));
+             } else {
+                 // unknown, but lowercase the name (our standard practice) and
+                 // remove any "x-" prefix
+@@ -878,6 +866,12 @@ QStringList QGenericUnixTheme::themeNames()
+                 result.push_back(s.startsWith(QLatin1String("x-")) ? s.mid(2) : s);
+             }
+         }
++        if (!result.contains(QLatin1String(QKdeTheme::name))) {
++            // prefer the GTK3 theme implementation with native dialogs etc.
++            result.push_back(QStringLiteral("gtk3"));
++            // fallback to the generic Gnome theme if loading the GTK3 theme fails
++            result.push_back(QLatin1String(QGnomeTheme::name));
++        }
+     } // desktopSettingsAware
+     result.append(QLatin1String(QGenericUnixTheme::name));
+     return result;

--- a/qtbase_6_3_0/0019-reset-current-context-on-error.patch
+++ b/qtbase_6_3_0/0019-reset-current-context-on-error.patch
@@ -1,0 +1,57 @@
+diff --git a/src/gui/kernel/qopenglcontext.cpp b/src/gui/kernel/qopenglcontext.cpp
+index 927e9cb94a..cab2740a4b 100644
+--- a/src/gui/kernel/qopenglcontext.cpp
++++ b/src/gui/kernel/qopenglcontext.cpp
+@@ -989,8 +989,17 @@ bool QOpenGLContext::makeCurrent(QSurface *surface)
+         return false;
+     }
+ 
+-    if (!d->platformGLContext->makeCurrent(surface->surfaceHandle()))
++    if (!d->platformGLContext->makeCurrent(surface->surfaceHandle())) {
++        // In this place the context could switch from isValid to !isValid.
++        // It may still be current (from the previous successful calls),
++        // so we need to make everything look as if it was not set current.
++        if (QOpenGLContext::currentContext() == this) {
++            // resources?..
++            QOpenGLContextPrivate::setCurrentContext(nullptr);
++            d->surface = nullptr;
++        }
+         return false;
++    }
+ 
+     QOpenGLContextPrivate::setCurrentContext(this);
+ #ifndef QT_NO_DEBUG
+@@ -1054,8 +1063,14 @@ bool QOpenGLContext::makeCurrent(QSurface *surface)
+ void QOpenGLContext::doneCurrent()
+ {
+     Q_D(QOpenGLContext);
+-    if (!isValid())
++    if (!isValid()) {
++        if (QOpenGLContext::currentContext() == this) {
++            // resources?..
++            QOpenGLContextPrivate::setCurrentContext(nullptr);
++            d->surface = nullptr;
++        }
+         return;
++    }
+ 
+     if (QOpenGLContext::currentContext() == this)
+         d->shareGroup->d_func()->deletePendingResources(this);
+@@ -1118,6 +1133,17 @@ void QOpenGLContext::swapBuffers(QSurface *surface)
+     if (surface->format().swapBehavior() == QSurfaceFormat::SingleBuffer)
+         functions()->glFlush();
+     d->platformGLContext->swapBuffers(surfaceHandle);
++
++    if (!isValid()) {
++        // The swapBuffers call could switch the context from isValid to !isValid.
++        // It may still be current (from the previous successful calls),
++        // so we need to make everything look as if it was not set current.
++        if (QOpenGLContext::currentContext() == this) {
++            // resources?..
++            QOpenGLContextPrivate::setCurrentContext(nullptr);
++            d->surface = nullptr;
++        }
++    }
+ }
+ 
+ /*!

--- a/qtbase_6_3_0/0020-reset-opengl-widget-on-context-loss.patch
+++ b/qtbase_6_3_0/0020-reset-opengl-widget-on-context-loss.patch
@@ -1,0 +1,145 @@
+diff --git a/src/opengl/qplatformbackingstoreopenglsupport.cpp b/src/opengl/qplatformbackingstoreopenglsupport.cpp
+index 30532c5b4b..11d43fc67b 100644
+--- a/src/opengl/qplatformbackingstoreopenglsupport.cpp
++++ b/src/opengl/qplatformbackingstoreopenglsupport.cpp
+@@ -147,11 +147,13 @@ QPlatformBackingStoreOpenGLSupport::~QPlatformBackingStoreOpenGLSupport() {
+         QOffscreenSurface offscreenSurface;
+         offscreenSurface.setFormat(context->format());
+         offscreenSurface.create();
+-        context->makeCurrent(&offscreenSurface);
+-        if (textureId)
+-            context->functions()->glDeleteTextures(1, &textureId);
+-        if (blitter)
+-            blitter->destroy();
++        if (context->makeCurrent(&offscreenSurface)) {
++            // Trying to fix a crash on context loss.
++            if (textureId)
++                context->functions()->glDeleteTextures(1, &textureId);
++            if (blitter)
++                blitter->destroy();
++        }
+     }
+     delete blitter;
+ }
+diff --git a/src/openglwidgets/qopenglwidget.cpp b/src/openglwidgets/qopenglwidget.cpp
+index 2ae1a7f215..6ceca4df87 100644
+--- a/src/openglwidgets/qopenglwidget.cpp
++++ b/src/openglwidgets/qopenglwidget.cpp
+@@ -591,9 +591,11 @@ void QOpenGLWidgetPaintDevice::ensureActiveTarget()
+     if (!wd->initialized)
+         return;
+ 
+-    if (QOpenGLContext::currentContext() != wd->context)
++    if (QOpenGLContext::currentContext() != wd->context) {
+         d->w->makeCurrent();
+-    else
++        if (!wd->initialized)
++            return; // Trying to fix a crash on context loss.
++    } else
+         wd->fbo->bind();
+ 
+     if (!wd->inPaintGL)
+@@ -673,7 +675,11 @@ void QOpenGLWidgetPrivate::recreateFbo()
+ 
+     emit q->aboutToResize();
+ 
+-    context->makeCurrent(surface);
++    if (!context->makeCurrent(surface)) {
++        // Trying to fix a crash on context loss.
++        reset();
++        return;
++    }
+ 
+     delete fbo;
+     fbo = nullptr;
+@@ -714,6 +720,9 @@ void QOpenGLWidgetPrivate::beginCompose()
+     if (flushPending) {
+         flushPending = false;
+         q->makeCurrent();
++        if (!initialized) {
++            return;
++        }
+         static_cast<QOpenGLExtensions *>(context->functions())->flushShared();
+     }
+     hasBeenComposed = true;
+@@ -756,6 +765,7 @@ void QOpenGLWidgetPrivate::initialize()
+     }
+     if (Q_UNLIKELY(!ctx->create())) {
+         qWarning("QOpenGLWidget: Failed to create context");
++        reset();
+         return;
+     }
+ 
+@@ -786,6 +796,7 @@ void QOpenGLWidgetPrivate::initialize()
+ 
+     if (Q_UNLIKELY(!ctx->makeCurrent(surface))) {
+         qWarning("QOpenGLWidget: Failed to make context current");
++        reset();
+         return;
+     }
+ 
+@@ -804,6 +815,9 @@ void QOpenGLWidgetPrivate::resolveSamples()
+     Q_Q(QOpenGLWidget);
+     if (resolvedFbo) {
+         q->makeCurrent();
++        if (!initialized) {
++            return;
++        }
+         QRect rect(QPoint(0, 0), fbo->size());
+         QOpenGLFramebufferObject::blitFramebuffer(resolvedFbo, rect, fbo, rect);
+         flushPending = true;
+@@ -837,6 +851,8 @@ void QOpenGLWidgetPrivate::render()
+         return;
+ 
+     q->makeCurrent();
++    if (!initialized)
++        return; // Trying to fix a crash on context loss.
+ 
+     if (updateBehavior == QOpenGLWidget::NoPartialUpdate && hasBeenComposed) {
+         invalidateFbo();
+@@ -883,14 +899,21 @@ QImage QOpenGLWidgetPrivate::grabFramebuffer()
+     if (!fbo) // could be completely offscreen, without ever getting a resize event
+         recreateFbo();
+ 
++    if (!fbo)
++        return QImage(); // Trying to fix a crash on context loss.
++
+     if (!inPaintGL)
+         render();
+ 
+     if (resolvedFbo) {
+         resolveSamples();
++        if (!initialized)
++            return QImage(); // Trying to fix a crash on context loss.
+         resolvedFbo->bind();
+     } else {
+         q->makeCurrent();
++        if (!initialized)
++            return QImage(); // Trying to fix a crash on context loss.
+     }
+ 
+     const bool hasAlpha = q->format().hasAlpha();
+@@ -1100,7 +1123,12 @@ void QOpenGLWidget::makeCurrent()
+     if (!d->initialized)
+         return;
+ 
+-    d->context->makeCurrent(d->surface);
++    if (!d->context->makeCurrent(d->surface)) {
++        // Trying to fix a crash on context loss.
++        // If makeCurrent() failed, that means we're not initialized any more.
++        d->initialized = false; // This prevents infinite recursion to makeCurrent().
++        d->reset();
++    }
+ 
+     if (d->fbo) // there may not be one if we are in reset()
+         d->fbo->bind();
+@@ -1230,6 +1258,9 @@ void QOpenGLWidget::resizeEvent(QResizeEvent *e)
+         return;
+ 
+     d->recreateFbo();
++    if (!d->fbo)
++        return; // Trying to fix a crash on context loss.
++
+     resizeGL(width(), height());
+     d->sendPaintEvent(QRect(QPoint(0, 0), size()));
+ }

--- a/qtbase_6_3_0/0021-enable-macos-10-12.patch
+++ b/qtbase_6_3_0/0021-enable-macos-10-12.patch
@@ -1,0 +1,45 @@
+diff --git a/cmake/QtAutoDetect.cmake b/cmake/QtAutoDetect.cmake
+index 8450035084..04632e47ef 100644
+--- a/cmake/QtAutoDetect.cmake
++++ b/cmake/QtAutoDetect.cmake
+@@ -347,7 +347,7 @@ function(qt_auto_detect_darwin)
+         if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
+             if(NOT CMAKE_SYSTEM_NAME)
+                 # macOS
+-                set(version "10.14")
++                set(version "10.12")
+             elseif(CMAKE_SYSTEM_NAME STREQUAL iOS)
+                 set(version "13.0")
+             elseif(CMAKE_SYSTEM_NAME STREQUAL watchOS)
+diff --git a/cmake/QtCompilerFlags.cmake b/cmake/QtCompilerFlags.cmake
+index 0954ba95c5..f3fbcc7fff 100644
+--- a/cmake/QtCompilerFlags.cmake
++++ b/cmake/QtCompilerFlags.cmake
+@@ -15,6 +15,14 @@ else()
+         list(APPEND _qt_compiler_warning_flags_on -Wall -Wextra)
+     endif()
+     list(APPEND _qt_compiler_warning_flags_off -w)
++
++    if (APPLE)
++        list(APPEND _qt_compiler_warning_flags_on
++            -Werror=unguarded-availability
++            -Werror=unguarded-availability-new
++            -Werror=unsupported-availability-guard
++        )
++    endif()
+ endif()
+ 
+ set(_qt_compiler_warning_flags_condition
+diff --git a/mkspecs/common/macx.conf b/mkspecs/common/macx.conf
+index b5427dd88c..4cb13ffa0a 100644
+--- a/mkspecs/common/macx.conf
++++ b/mkspecs/common/macx.conf
+@@ -5,7 +5,7 @@
+ QMAKE_PLATFORM         += macos osx macx
+ QMAKE_MAC_SDK           = macosx
+ 
+-QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.14
++QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.12
+ 
+ QT_MAC_SDK_VERSION_MIN = 10.15
+ 

--- a/qtbase_6_3_0/0022-posix_memalign-for-10-12.patch
+++ b/qtbase_6_3_0/0022-posix_memalign-for-10-12.patch
@@ -1,0 +1,39 @@
+diff --git a/src/corelib/kernel/qmetatype.cpp b/src/corelib/kernel/qmetatype.cpp
+index 65745bf06a..a873061694 100644
+--- a/src/corelib/kernel/qmetatype.cpp
++++ b/src/corelib/kernel/qmetatype.cpp
+@@ -590,11 +590,21 @@ void *QMetaType::create(const void *copy) const
+ {
+     if (d_ptr && (copy ? !!d_ptr->copyCtr : !!d_ptr->defaultCtr)) {
+         void *where =
++// Patch: operator new(size, alignment) is available only on 10.14+.
++#ifdef Q_OS_MAC
++            nullptr;
++        if (d_ptr->alignment > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
++            posix_memalign(&where, d_ptr->alignment, d_ptr->size);
++        } else {
++            where = operator new(d_ptr->size);
++        }
++#else
+ #ifdef __STDCPP_DEFAULT_NEW_ALIGNMENT__
+             d_ptr->alignment > __STDCPP_DEFAULT_NEW_ALIGNMENT__ ?
+                 operator new(d_ptr->size, std::align_val_t(d_ptr->alignment)) :
+ #endif
+                 operator new(d_ptr->size);
++#endif
+         return construct(where, copy);
+     }
+     return nullptr;
+@@ -615,7 +625,12 @@ void QMetaType::destroy(void *data) const
+         if (d_ptr->dtor)
+             d_ptr->dtor(d_ptr, data);
+         if (d_ptr->alignment > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
++// Patch: operator new(size, alignment) is available only on 10.14+.
++#ifdef Q_OS_MAC
++            std::free(data);
++#else
+             operator delete(data, std::align_val_t(d_ptr->alignment));
++#endif
+         } else {
+             operator delete(data);
+         }

--- a/qtbase_6_3_0/0023-optional-value-10-12.patch
+++ b/qtbase_6_3_0/0023-optional-value-10-12.patch
@@ -1,0 +1,26 @@
+diff --git a/src/corelib/text/qstringconverter.cpp b/src/corelib/text/qstringconverter.cpp
+index df9efe7f67..03f37b123d 100644
+--- a/src/corelib/text/qstringconverter.cpp
++++ b/src/corelib/text/qstringconverter.cpp
+@@ -1700,7 +1700,7 @@ QStringConverter::QStringConverter(const char *name, Flags f)
+ {
+     auto e = encodingForName(name);
+     if (e)
+-        iface = encodingInterfaces + int(e.value());
++        iface = encodingInterfaces + int(*e);
+ }
+ 
+ /*!
+diff --git a/src/xml/dom/qdom.cpp b/src/xml/dom/qdom.cpp
+index 85718cd5e0..5ef55b4f93 100644
+--- a/src/xml/dom/qdom.cpp
++++ b/src/xml/dom/qdom.cpp
+@@ -5914,7 +5914,7 @@ void QDomDocumentPrivate::saveDocument(QTextStream& s, const int indent, QDomNod
+                 if (!encoding)
+                     qWarning() << "QDomDocument::save(): Unsupported encoding" << enc << "specified.";
+                 else
+-                    s.setEncoding(encoding.value());
++                    s.setEncoding(*encoding);
+             }
+         }
+ #endif

--- a/qtbase_6_3_0/0024-nscolor-type-10-12.patch
+++ b/qtbase_6_3_0/0024-nscolor-type-10-12.patch
@@ -1,0 +1,69 @@
+diff --git a/src/gui/painting/qcoregraphics.mm b/src/gui/painting/qcoregraphics.mm
+index ef29f4a490..ba843b7059 100644
+--- a/src/gui/painting/qcoregraphics.mm
++++ b/src/gui/painting/qcoregraphics.mm
+@@ -243,32 +243,29 @@ QColor qt_mac_toQColor(CGColorRef color)
+ QColor qt_mac_toQColor(const NSColor *color)
+ {
+     QColor qtColor;
+-    switch (color.type) {
+-    case NSColorTypeComponentBased: {
++    // Patch: NSColor.type was added in 10.13.
++    if (__builtin_available(macOS 10.13, *)) {
++        if (color.type == NSColorTypeComponentBased) {
+         const NSColorSpace *colorSpace = [color colorSpace];
+         if (colorSpace == NSColorSpace.genericRGBColorSpace
+             && color.numberOfComponents == 4) { // rbga
+             CGFloat components[4];
+             [color getComponents:components];
+             qtColor.setRgbF(components[0], components[1], components[2], components[3]);
+-            break;
++            return qtColor;
+         } else if (colorSpace == NSColorSpace.genericCMYKColorSpace
+                    && color.numberOfComponents == 5) { // cmyk + alpha
+             CGFloat components[5];
+             [color getComponents:components];
+             qtColor.setCmykF(components[0], components[1], components[2], components[3], components[4]);
+-            break;
++            return qtColor;
++        }
+         }
+     }
+-        Q_FALLTHROUGH();
+-    default: {
+         const NSColor *tmpColor = [color colorUsingColorSpace:NSColorSpace.genericRGBColorSpace];
+         CGFloat red = 0, green = 0, blue = 0, alpha = 0;
+         [tmpColor getRed:&red green:&green blue:&blue alpha:&alpha];
+         qtColor.setRgbF(red, green, blue, alpha);
+-        break;
+-    }
+-    }
+ 
+     return qtColor;
+ }
+@@ -295,9 +292,10 @@ static bool qt_mac_isSystemColorOrInstance(const NSColor *color, NSString *color
+     // We specifically do not want isKindOfClass: here
+     if ([color.className isEqualToString:className]) // NSPatternColorSpace
+         return true;
+-    if (color.type == NSColorTypeCatalog &&
+-        [color.catalogNameComponent isEqualToString:@"System"] &&
+-        [color.colorNameComponent isEqualToString:colorNameComponent])
++    // Patch: NSColor.type was added in 10.13.
++    if ([color.catalogNameComponent isEqualToString:@"System"] &&
++        [color.colorNameComponent isEqualToString:colorNameComponent] &&
++        [color.colorSpaceName isEqualToString:NSNamedColorSpace])
+         return true;
+     return false;
+ }
+@@ -353,8 +351,9 @@ QBrush qt_mac_toQBrush(const NSColor *color, QPalette::ColorGroup colorGroup)
+         return qtBrush;
+     }
+ 
+-    if (color.type == NSColorTypePattern) {
+-        NSImage *patternImage = color.patternImage;
++    // Patch: NSColor.type was added in 10.13.
++    if (NSColor *patternColor = [color colorUsingColorSpaceName:NSPatternColorSpace]) {
++        NSImage *patternImage = patternColor.patternImage;
+         const QSizeF sz(patternImage.size.width, patternImage.size.height);
+         // FIXME: QBrush is not resolution independent (QTBUG-49774)
+         qtBrush.setTexture(qt_mac_toQPixmap(patternImage, sz));

--- a/qtbase_6_3_0/0025-fix-qrhimetal-for-10-12.patch
+++ b/qtbase_6_3_0/0025-fix-qrhimetal-for-10-12.patch
@@ -1,0 +1,166 @@
+diff --git a/src/gui/rhi/qrhimetal.mm b/src/gui/rhi/qrhimetal.mm
+index e169550ee4..4c97dd15b7 100644
+--- a/src/gui/rhi/qrhimetal.mm
++++ b/src/gui/rhi/qrhimetal.mm
+@@ -40,6 +40,7 @@
+ #include "qrhimetal_p_p.h"
+ #include <QGuiApplication>
+ #include <QWindow>
++#include <QOperatingSystemVersion>
+ #include <qmath.h>
+ 
+ #ifdef Q_OS_MACOS
+@@ -211,8 +212,8 @@ struct QRhiMetalData
+     };
+     QVarLengthArray<TextureReadback, 2> activeTextureReadbacks;
+ 
+-    MTLCaptureManager *captureMgr;
+-    id<MTLCaptureScope> captureScope = nil;
++    API_AVAILABLE(macos(10.13), ios(11.0)) MTLCaptureManager *captureMgr;
++    API_AVAILABLE(macos(10.13), ios(11.0)) id<MTLCaptureScope> captureScope = nil;
+ 
+     static const int TEXBUF_ALIGN = 256; // probably not accurate
+ 
+@@ -377,7 +378,8 @@ bool QRhiMetal::create(QRhi::Flags flags)
+     const QString deviceName = QString::fromNSString([d->dev name]);
+     qCDebug(QRHI_LOG_INFO, "Metal device: %s", qPrintable(deviceName));
+     driverInfoStruct.deviceName = deviceName.toUtf8();
+-    driverInfoStruct.deviceId = [d->dev registryID];
++    if (@available(macOS 10.13, *))
++        driverInfoStruct.deviceId = [d->dev registryID];
+ #ifdef Q_OS_IOS
+     driverInfoStruct.deviceType = QRhiDriverInfo::IntegratedDevice;
+ #else
+@@ -404,14 +406,15 @@ bool QRhiMetal::create(QRhi::Flags flags)
+     else
+         d->cmdQueue = [d->dev newCommandQueue];
+ 
+-    d->captureMgr = [MTLCaptureManager sharedCaptureManager];
+-    // Have a custom capture scope as well which then shows up in XCode as
+-    // an option when capturing, and becomes especially useful when having
+-    // multiple windows with multiple QRhis.
+-    d->captureScope = [d->captureMgr newCaptureScopeWithCommandQueue: d->cmdQueue];
+-    const QString label = QString::asprintf("Qt capture scope for QRhi %p", this);
+-    d->captureScope.label = label.toNSString();
+-
++    if (@available(macOS 10.13, iOS 11.0, *)) {
++        d->captureMgr = [MTLCaptureManager sharedCaptureManager];
++        // Have a custom capture scope as well which then shows up in XCode as
++        // an option when capturing, and becomes especially useful when having
++        // multiple windows with multiple QRhis.
++        d->captureScope = [d->captureMgr newCaptureScopeWithCommandQueue: d->cmdQueue];
++        const QString label = QString::asprintf("Qt capture scope for QRhi %p", this);
++        d->captureScope.label = label.toNSString();
++    }
+ #if defined(Q_OS_MACOS)
+     caps.maxTextureSize = 16384;
+     caps.baseVertexAndInstance = true;
+@@ -455,8 +458,10 @@ void QRhiMetal::destroy()
+         s.destroy();
+     d->shaderCache.clear();
+ 
+-    [d->captureScope release];
+-    d->captureScope = nil;
++    if (@available(macOS 10.13, iOS 11.0, *)) {
++        [d->captureScope release];
++        d->captureScope = nil;
++    }
+ 
+     [d->cmdQueue release];
+     if (!importedCmdQueue)
+@@ -1367,7 +1372,8 @@ void QRhiMetal::debugMarkBegin(QRhiCommandBuffer *cb, const QByteArray &name)
+     if (cbD->recordingPass != QMetalCommandBuffer::NoPass)
+         [cbD->d->currentRenderPassEncoder pushDebugGroup: str];
+     else
+-        [cbD->d->cb pushDebugGroup: str];
++        if (@available(macOS 10.13, iOS 11.0, *))
++            [cbD->d->cb pushDebugGroup: str];
+ }
+ 
+ void QRhiMetal::debugMarkEnd(QRhiCommandBuffer *cb)
+@@ -1379,7 +1385,8 @@ void QRhiMetal::debugMarkEnd(QRhiCommandBuffer *cb)
+     if (cbD->recordingPass != QMetalCommandBuffer::NoPass)
+         [cbD->d->currentRenderPassEncoder popDebugGroup];
+     else
+-        [cbD->d->cb popDebugGroup];
++        if (@available(macOS 10.13, iOS 11.0, *))
++            [cbD->d->cb popDebugGroup];
+ }
+ 
+ void QRhiMetal::debugMarkMsg(QRhiCommandBuffer *cb, const QByteArray &msg)
+@@ -1430,7 +1437,8 @@ QRhi::FrameOpResult QRhiMetal::beginFrame(QRhiSwapChain *swapChain, QRhi::BeginF
+     if (swapChainD->ds)
+         swapChainD->ds->lastActiveFrameSlot = currentFrameSlot;
+ 
+-    [d->captureScope beginScope];
++    if (@available(macOS 10.13, iOS 11.0, *))
++        [d->captureScope beginScope];
+ 
+     // Do not let the command buffer mess with the refcount of objects. We do
+     // have a proper render loop and will manage lifetimes similarly to other
+@@ -1487,7 +1495,8 @@ QRhi::FrameOpResult QRhiMetal::endFrame(QRhiSwapChain *swapChain, QRhi::EndFrame
+     QRhiProfilerPrivate *rhiP = profilerPrivateOrNull();
+     QRHI_PROF_F(endSwapChainFrame(swapChain, swapChainD->frameCount + 1));
+ 
+-    [d->captureScope endScope];
++    if (@available(macOS 10.13, iOS 11.0, *))
++        [d->captureScope endScope];
+ 
+     if (needsPresent)
+         swapChainD->currentFrameSlot = (swapChainD->currentFrameSlot + 1) % QMTL_FRAMES_IN_FLIGHT;
+@@ -3244,7 +3253,10 @@ static inline MTLVertexFormat toMetalAttributeFormat(QRhiVertexInputAttribute::F
+     case QRhiVertexInputAttribute::UNormByte2:
+         return MTLVertexFormatUChar2Normalized;
+     case QRhiVertexInputAttribute::UNormByte:
+-        return MTLVertexFormatUCharNormalized;
++        if (@available(macOS 10.13, iOS 11.0, *))
++            return MTLVertexFormatUCharNormalized;
++        else
++            Q_UNREACHABLE();
+     case QRhiVertexInputAttribute::UInt4:
+         return MTLVertexFormatUInt4;
+     case QRhiVertexInputAttribute::UInt3:
+@@ -3434,9 +3446,10 @@ static inline MTLCullMode toMetalCullMode(QRhiGraphicsPipeline::CullMode c)
+ id<MTLLibrary> QRhiMetalData::createMetalLib(const QShader &shader, QShader::Variant shaderVariant,
+                                              QString *error, QByteArray *entryPoint, QShaderKey *activeKey)
+ {
++    const auto mtl20supported = (QOperatingSystemVersion::current() >= QOperatingSystemVersion::MacOSHighSierra);
+     QShaderKey key = { QShader::MetalLibShader, 20, shaderVariant };
+     QShaderCode mtllib = shader.shader(key);
+-    if (mtllib.shader().isEmpty()) {
++    if (!mtl20supported || mtllib.shader().isEmpty()) {
+         key.setSourceVersion(12);
+         mtllib = shader.shader(key);
+     }
+@@ -3460,7 +3473,7 @@ id<MTLLibrary> QRhiMetalData::createMetalLib(const QShader &shader, QShader::Var
+ 
+     key = { QShader::MslShader, 20, shaderVariant };
+     QShaderCode mslSource = shader.shader(key);
+-    if (mslSource.shader().isEmpty()) {
++    if (!mtl20supported || mslSource.shader().isEmpty()) {
+         key.setSourceVersion(12);
+         mslSource = shader.shader(key);
+     }
+@@ -3471,7 +3484,11 @@ id<MTLLibrary> QRhiMetalData::createMetalLib(const QShader &shader, QShader::Var
+ 
+     NSString *src = [NSString stringWithUTF8String: mslSource.shader().constData()];
+     MTLCompileOptions *opts = [[MTLCompileOptions alloc] init];
+-    opts.languageVersion = key.sourceVersion() == 20 ? MTLLanguageVersion2_0 : MTLLanguageVersion1_2;
++    if (@available(macOS 10.13, *)) {
++        opts.languageVersion = key.sourceVersion() == 20 ? MTLLanguageVersion2_0 : MTLLanguageVersion1_2;
++    } else {
++        opts.languageVersion = MTLLanguageVersion1_2;
++    }
+     NSError *err = nil;
+     id<MTLLibrary> lib = [dev newLibraryWithSource: src options: opts error: &err];
+     [opts release];
+@@ -3998,7 +4015,8 @@ bool QMetalSwapChain::createOrResize()
+ 
+ #ifdef Q_OS_MACOS
+     if (m_flags.testFlag(NoVSync))
+-        d->layer.displaySyncEnabled = NO;
++        if (@available(macOS 10.13, *))
++            d->layer.displaySyncEnabled = NO;
+ #endif
+ 
+     if (m_flags.testFlag(SurfaceHasPreMulAlpha)) {

--- a/qtbase_6_3_0/0026-fix-qcocoacolordialoghelper-for-10-12.patch
+++ b/qtbase_6_3_0/0026-fix-qcocoacolordialoghelper-for-10-12.patch
@@ -1,0 +1,64 @@
+diff --git a/src/plugins/platforms/cocoa/qcocoacolordialoghelper.mm b/src/plugins/platforms/cocoa/qcocoacolordialoghelper.mm
+index 5ad1f9d7bb..c9fa035d87 100644
+--- a/src/plugins/platforms/cocoa/qcocoacolordialoghelper.mm
++++ b/src/plugins/platforms/cocoa/qcocoacolordialoghelper.mm
+@@ -180,34 +180,34 @@ QT_NAMESPACE_ALIAS_OBJC_CLASS(QNSColorPanelDelegate);
+ 
+ - (void)updateQtColor
+ {
+-    // Discard the color space and pass the color components to QColor. This
+-    // is a good option as long as QColor is color-unmanaged: we preserve the
+-    // exact RGB value from the color picker, which is predictable. Further,
+-    // painting with the color will reproduce the same color on-screen, as
+-    // long as the the same screen is used for selecting the color.
+-    NSColor *componentColor = [[mColorPanel color] colorUsingType:NSColorTypeComponentBased];
+-    switch (componentColor.colorSpace.colorSpaceModel)
+-    {
+-    case NSColorSpaceModelGray: {
+-        CGFloat white = 0, alpha = 0;
+-        [componentColor getWhite:&white alpha:&alpha];
+-        mQtColor.setRgbF(white, white, white, alpha);
+-    } break;
+-    case NSColorSpaceModelRGB: {
+-        CGFloat red = 0, green = 0, blue = 0, alpha = 0;
+-        [componentColor getRed:&red green:&green blue:&blue alpha:&alpha];
+-        mQtColor.setRgbF(red, green, blue, alpha);
+-    } break;
+-    case NSColorSpaceModelCMYK: {
++    NSColor *color = [mColorPanel color];
++    NSString *colorSpaceName = [color colorSpaceName];
++    if (colorSpaceName == NSDeviceCMYKColorSpace) {
+         CGFloat cyan = 0, magenta = 0, yellow = 0, black = 0, alpha = 0;
+-        [componentColor getCyan:&cyan magenta:&magenta yellow:&yellow black:&black alpha:&alpha];
++        [color getCyan:&cyan magenta:&magenta yellow:&yellow black:&black alpha:&alpha];
+         mQtColor.setCmykF(cyan, magenta, yellow, black, alpha);
+-    } break;
+-    default:
+-        qWarning("QNSColorPanelDelegate: Unsupported color space model");
+-    break;
++    } else if (colorSpaceName == NSCalibratedRGBColorSpace || colorSpaceName == NSDeviceRGBColorSpace)  {
++        CGFloat red = 0, green = 0, blue = 0, alpha = 0;
++        [color getRed:&red green:&green blue:&blue alpha:&alpha];
++        mQtColor.setRgbF(red, green, blue, alpha);
++    } else if (colorSpaceName == NSNamedColorSpace) {
++        NSColor *tmpColor = [color colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
++        CGFloat red = 0, green = 0, blue = 0, alpha = 0;
++        [tmpColor getRed:&red green:&green blue:&blue alpha:&alpha];
++        mQtColor.setRgbF(red, green, blue, alpha);
++    } else {
++        NSColorSpace *colorSpace = [color colorSpace];
++        if ([colorSpace colorSpaceModel] == NSCMYKColorSpaceModel && [color numberOfComponents] == 5){
++            CGFloat components[5];
++            [color getComponents:components];
++            mQtColor.setCmykF(components[0], components[1], components[2], components[3], components[4]);
++        } else {
++            NSColor *tmpColor = [color colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
++            CGFloat red = 0, green = 0, blue = 0, alpha = 0;
++            [tmpColor getRed:&red green:&green blue:&blue alpha:&alpha];
++            mQtColor.setRgbF(red, green, blue, alpha);
++        }
+     }
+-
+     if (mHelper)
+         emit mHelper->currentColorChanged(mQtColor);
+ }

--- a/qtbase_6_3_0/0027-fix-qcocoadrag-for-10-12.patch
+++ b/qtbase_6_3_0/0027-fix-qcocoadrag-for-10-12.patch
@@ -1,0 +1,31 @@
+diff --git a/src/plugins/platforms/cocoa/qcocoadrag.mm b/src/plugins/platforms/cocoa/qcocoadrag.mm
+index 4bd1b129bd..6f4fab9210 100644
+--- a/src/plugins/platforms/cocoa/qcocoadrag.mm
++++ b/src/plugins/platforms/cocoa/qcocoadrag.mm
+@@ -131,7 +131,7 @@ Qt::DropAction QCocoaDrag::drag(QDrag *o)
+     m_drag = o;
+     m_executed_drop_action = Qt::IgnoreAction;
+ 
+-    QMacPasteboard dragBoard(CFStringRef(NSPasteboardNameDrag), QMacInternalPasteboardMime::MIME_DND);
++    QMacPasteboard dragBoard(CFStringRef(NSDragPboard), QMacInternalPasteboardMime::MIME_DND);
+     m_drag->mimeData()->setData(QLatin1String("application/x-qt-mime-type-name"), QByteArray("dummy"));
+     dragBoard.setMimeData(m_drag->mimeData(), QMacPasteboard::LazyRequest);
+ 
+@@ -150,7 +150,7 @@ Qt::DropAction QCocoaDrag::drag(QDrag *o)
+     CGFloat flippedY = dragImage.size.height - hotSpot.y();
+     event_location.y -= flippedY;
+     NSSize mouseOffset_unused = NSMakeSize(0.0, 0.0);
+-    NSPasteboard *pboard = [NSPasteboard pasteboardWithName:NSPasteboardNameDrag];
++    NSPasteboard *pboard = [NSPasteboard pasteboardWithName:NSDragPboard];
+ 
+     [theWindow dragImage:dragImage
+         at:event_location
+@@ -185,7 +185,7 @@ bool QCocoaDrag::maybeDragMultipleItems()
+     auto *sourceView = static_cast<NSView<NSDraggingSource>*>(theWindow.contentView);
+ 
+     const auto &qtUrls = m_drag->mimeData()->urls();
+-    NSPasteboard *dragBoard = [NSPasteboard pasteboardWithName:NSPasteboardNameDrag];
++    NSPasteboard *dragBoard = [NSPasteboard pasteboardWithName:NSDragPboard];
+ 
+     if (qtUrls.size() <= 1) {
+         // Good old -dragImage: works perfectly for this ...

--- a/qtbase_6_3_0/0028-fix-qnsview_dragging-for-10-12.patch
+++ b/qtbase_6_3_0/0028-fix-qnsview_dragging-for-10-12.patch
@@ -1,0 +1,29 @@
+diff --git a/src/plugins/platforms/cocoa/qnsview_dragging.mm b/src/plugins/platforms/cocoa/qnsview_dragging.mm
+index 6ea96ac956..d0611fd1cd 100644
+--- a/src/plugins/platforms/cocoa/qnsview_dragging.mm
++++ b/src/plugins/platforms/cocoa/qnsview_dragging.mm
+@@ -46,13 +46,22 @@
+     QMacAutoReleasePool pool;
+ 
+     NSString * const mimeTypeGeneric = @"com.trolltech.qt.MimeTypeName";
++    NSString * urlType = nullptr;
++    NSString * fileUrlType = nullptr;
++    if (@available(macOS 10.13, *)) {
++        urlType = NSPasteboardTypeURL;
++        fileUrlType = NSPasteboardTypeFileURL;
++    } else {
++        urlType = NSURLPboardType;
++        fileUrlType = NSFilenamesPboardType;
++    }
+     NSMutableArray<NSString *> *supportedTypes = [NSMutableArray<NSString *> arrayWithArray:@[
+                    NSPasteboardTypeColor, NSPasteboardTypeString,
+-                   NSPasteboardTypeFileURL, @"com.adobe.encapsulated-postscript", NSPasteboardTypeTIFF,
++                   fileUrlType, @"com.adobe.encapsulated-postscript", NSPasteboardTypeTIFF,
+                    NSPasteboardTypeRTF, NSPasteboardTypeTabularText, NSPasteboardTypeFont,
+                    NSPasteboardTypeRuler, NSFileContentsPboardType,
+                    NSPasteboardTypeRTFD , NSPasteboardTypeHTML,
+-                   NSPasteboardTypeURL, NSPasteboardTypePDF, (NSString *)kUTTypeVCard,
++                   urlType, NSPasteboardTypePDF, (NSString *)kUTTypeVCard,
+                    (NSString *)kPasteboardTypeFileURLPromise, (NSString *)kUTTypeInkText,
+                    NSPasteboardTypeMultipleTextSelection, mimeTypeGeneric]];
+ 

--- a/qtbase_6_3_0/0029-fix-qcocoawindow-for-10-12.patch
+++ b/qtbase_6_3_0/0029-fix-qcocoawindow-for-10-12.patch
@@ -1,0 +1,21 @@
+diff --git a/src/plugins/platforms/cocoa/qcocoawindow.mm b/src/plugins/platforms/cocoa/qcocoawindow.mm
+index 24e98f5bac..454beed5fe 100644
+--- a/src/plugins/platforms/cocoa/qcocoawindow.mm
++++ b/src/plugins/platforms/cocoa/qcocoawindow.mm
+@@ -1722,10 +1722,12 @@ void QCocoaWindow::setWindowCursor(NSCursor *cursor)
+ void QCocoaWindow::registerTouch(bool enable)
+ {
+     m_registerTouchCount += enable ? 1 : -1;
+-    if (enable && m_registerTouchCount == 1)
+-        m_view.allowedTouchTypes |= NSTouchTypeMaskIndirect;
+-    else if (m_registerTouchCount == 0)
+-        m_view.allowedTouchTypes &= ~NSTouchTypeMaskIndirect;
++    if (__builtin_available(macOS 10.12.2, *)) {
++        if (enable && m_registerTouchCount == 1)
++            m_view.allowedTouchTypes |= NSTouchTypeMaskIndirect;
++        else if (m_registerTouchCount == 0)
++            m_view.allowedTouchTypes &= ~NSTouchTypeMaskIndirect;
++    }
+ }
+ 
+ void QCocoaWindow::setContentBorderThickness(int topThickness, int bottomThickness)

--- a/qtbase_6_3_0/0030-qtgui-dlopen.patch
+++ b/qtbase_6_3_0/0030-qtgui-dlopen.patch
@@ -1,0 +1,15 @@
+diff --git a/src/gui/CMakeLists.txt b/src/gui/CMakeLists.txt
+index 905afd4038..4715a8b31e 100644
+--- a/src/gui/CMakeLists.txt
++++ b/src/gui/CMakeLists.txt
+@@ -843,8 +843,8 @@ qt_internal_extend_target(Gui CONDITION QT_FEATURE_egl AND NOT QT_FEATURE_egl_x1
+         QT_EGL_NO_X11
+ )
+ 
+-qt_internal_extend_target(Gui CONDITION QT_FEATURE_dlopen AND QT_FEATURE_egl
+-    LIBRARIES
++qt_internal_extend_target(Gui CONDITION QT_FEATURE_dlopen
++    PUBLIC_LIBRARIES
+         ${CMAKE_DL_LIBS}
+ )
+ 

--- a/qtbase_6_3_0/0031-fix-imes-on-macos.patch
+++ b/qtbase_6_3_0/0031-fix-imes-on-macos.patch
@@ -1,0 +1,36 @@
+diff --git a/src/gui/kernel/qshortcutmap.cpp b/src/gui/kernel/qshortcutmap.cpp
+index cf729d28c4..731bbe108d 100644
+--- a/src/gui/kernel/qshortcutmap.cpp
++++ b/src/gui/kernel/qshortcutmap.cpp
+@@ -528,7 +528,30 @@ void QShortcutMap::createNewSequences(QKeyEvent *e, QList<QKeySequence> &ksl, in
+     qCDebug(lcShortcutMap) << "Creating new sequences for" << e
+         << "with ignoredModifiers=" << Qt::KeyboardModifiers(ignoredModifiers);
+     int pkTotal = possibleKeys.count();
+-    if (!pkTotal)
++
++    // Patch: Fix IMEs on macOS.
++    //
++    // See https://github.com/telegramdesktop/tdesktop/issues/17242
++    //
++    // In case non-standard IMEs are used getting the
++    // kTISPropertyUnicodeKeyLayoutData for the input source in
++    // qapplekeymapper.mm gives nullptr and commit in qtbase:
++    //
++    // 6faa33192c99f3432b28591b991918b47bd6fa09
++    //
++    // removed a fallback, returning just a single zero possible key:
++    //
++    //    But in those cases we should not
++    //    fall back to the Qt key from the key event, as that doesn't
++    //    match what the keyboard layout defines. Most keyboard layouts
++    //    explicitly define the base key as the key for these "undefined"
++    //    mappings, but if the keyboard layout does not, we should not
++    //    produce any input in the application, to match what AppKit does
++    //    in this case.
++    //
++    // Otherwise this keys list always produces a partial shortcut match.
++    //
++    if (!pkTotal || (pkTotal == 1 && !possibleKeys[0]))
+         return;
+ 
+     int ssActual = d->currentSequences.count();

--- a/qtbase_6_3_0/0032-fix-search-in-finder-macos.patch
+++ b/qtbase_6_3_0/0032-fix-search-in-finder-macos.patch
@@ -1,0 +1,15 @@
+diff --git a/src/plugins/platforms/cocoa/qcocoafiledialoghelper.mm b/src/plugins/platforms/cocoa/qcocoafiledialoghelper.mm
+index e84d50d729..53c492436c 100644
+--- a/src/plugins/platforms/cocoa/qcocoafiledialoghelper.mm
++++ b/src/plugins/platforms/cocoa/qcocoafiledialoghelper.mm
+@@ -406,6 +406,10 @@ typedef QSharedPointer<QFileDialogOptions> SharedPointerFileDialogOptions;
+ {
+     Q_UNUSED(sender);
+ 
++    // Patch: Fix crash when searching in Finder.
++    if (!path || [path isEqual:[NSNull null]])
++        return;
++
+     if (!(path && path.length) || [path isEqualToString:m_currentDirectory])
+         return;
+ 

--- a/qtbase_6_3_0/0033-add-scroll-wheel-logs.patch
+++ b/qtbase_6_3_0/0033-add-scroll-wheel-logs.patch
@@ -1,0 +1,100 @@
+diff --git a/src/plugins/platforms/xcb/qxcbconnection.cpp b/src/plugins/platforms/xcb/qxcbconnection.cpp
+index b19b070a4d..348cba4ef5 100644
+--- a/src/plugins/platforms/xcb/qxcbconnection.cpp
++++ b/src/plugins/platforms/xcb/qxcbconnection.cpp
+@@ -706,6 +706,12 @@ void QXcbConnection::handleXcbEvent(xcb_generic_event_t *event)
+         break;
+     }
+     case XCB_GE_GENERIC:
++
++        if (hasXInput2() && isXIType(event, XCB_INPUT_MOTION)) {
++            // Patch: Debug #17254
++            qCDebug(lcQpaXInputEvents) << "(tdesktop) scroll wheel got in XCB_GE_GENERIC";
++        }
++
+         // Here the windowEventListener is invoked from xi2HandleEvent()
+         if (hasXInput2() && isXIEvent(event))
+             xi2HandleEvent(reinterpret_cast<xcb_ge_event_t *>(event));
+@@ -949,16 +955,25 @@ bool QXcbConnection::compressEvent(xcb_generic_event_t *event) const
+ 
+         // compress XI_Motion
+         if (isXIType(event, XCB_INPUT_MOTION)) {
++
++            // Patch: Debug #17254
++            qCDebug(lcQpaXInputEvents) << "(tdesktop) scroll wheel check XCB_INPUT_MOTION compress";
++
+ #if QT_CONFIG(tabletevent)
+             auto xdev = reinterpret_cast<xcb_input_motion_event_t *>(event);
+             if (!QCoreApplication::testAttribute(Qt::AA_CompressTabletEvents) &&
+                     const_cast<QXcbConnection *>(this)->tabletDataForDevice(xdev->sourceid))
+                 return false;
+ #endif // QT_CONFIG(tabletevent)
+-            return m_eventQueue->peek(QXcbEventQueue::PeekRetainMatch,
++            const auto compressed = m_eventQueue->peek(QXcbEventQueue::PeekRetainMatch,
+                                       [this](xcb_generic_event_t *next, int) {
+                 return isXIType(next, XCB_INPUT_MOTION);
+             });
++
++            // Patch: Debug #17254
++            qCDebug(lcQpaXInputEvents) << "(tdesktop) scroll wheel compress XCB_INPUT_MOTION" << (compressed ? "YES" : "NO");
++
++            return compressed;
+         }
+ 
+         // compress XI_TouchUpdate for the same touch point id
+diff --git a/src/plugins/platforms/xcb/qxcbconnection_xi2.cpp b/src/plugins/platforms/xcb/qxcbconnection_xi2.cpp
+index 9abdfd422b..6c891cd2e1 100644
+--- a/src/plugins/platforms/xcb/qxcbconnection_xi2.cpp
++++ b/src/plugins/platforms/xcb/qxcbconnection_xi2.cpp
+@@ -652,6 +652,10 @@ void QXcbConnection::xi2HandleEvent(xcb_ge_event_t *event)
+     case XCB_INPUT_TOUCH_END:
+     {
+         xiDeviceEvent = xiEvent;
++
++        // Patch: Debug #17254
++        qCDebug(lcQpaXInputEvents) << "(tdesktop) scroll wheel got event" << int(xiEvent->event_type) << "in xi2HandleEvent";
++
+         eventListener = windowEventListenerFromId(xiDeviceEvent->event);
+         sourceDeviceId = xiDeviceEvent->sourceid; // use the actual device id instead of the master
+         break;
+@@ -687,6 +691,10 @@ void QXcbConnection::xi2HandleEvent(xcb_ge_event_t *event)
+     }
+ #endif // QT_CONFIG(tabletevent)
+ 
++    // Patch: Debug #17254
++    if (xiEvent->event_type == XCB_INPUT_MOTION)
++        qCDebug(lcQpaXInputEvents) << "(tdesktop) scroll wheel got input_motion in xi2HandleEvent";
++
+     if (auto device = QPointingDevicePrivate::pointingDeviceById(sourceDeviceId))
+         xi2HandleScrollEvent(event, device);
+ 
+@@ -1065,13 +1073,29 @@ void QXcbConnection::xi2HandleScrollEvent(void *event, const QPointingDevice *de
+ {
+     auto *xiDeviceEvent = reinterpret_cast<qt_xcb_input_device_event_t *>(event);
+ 
++    // Patch: Debug #17254
++    qCDebug(lcQpaXInputEvents) << "(tdesktop) scroll wheel got in xi2HandleScrollEvent";
++
+     const QXcbScrollingDevice *scrollDev = qobject_cast<const QXcbScrollingDevice *>(dev);
++
++    // Patch: Debug #17254
++    qCDebug(lcQpaXInputEvents) << "(tdesktop) scroll wheel got scrollDev" << quintptr(scrollDev);
++
+     if (!scrollDev || !scrollDev->capabilities().testFlag(QInputDevice::Capability::Scroll))
+         return;
+     const QXcbScrollingDevicePrivate *scrollingDevice = QXcbScrollingDevice::get(scrollDev);
+ 
++    // Patch: Debug #17254
++    qCDebug(lcQpaXInputEvents) << "(tdesktop) scroll wheel from device" << scrollingDevice->systemId << "got device";
++
+     if (xiDeviceEvent->event_type == XCB_INPUT_MOTION && scrollingDevice->orientations) {
++        // Patch: Debug #17254
++        qCDebug(lcQpaXInputEvents) << "(tdesktop) scroll wheel from device" << scrollingDevice->systemId << "got XCB_INPUT_MOTION";
++
+         if (QXcbWindow *platformWindow = platformWindowFromId(xiDeviceEvent->event)) {
++            // Patch: Debug #17254
++            qCDebug(lcQpaXInputEvents) << "(tdesktop) scroll wheel from device" << scrollingDevice->systemId << "got playformWindow";
++
+             QPoint rawDelta;
+             QPoint angleDelta;
+             double value;

--- a/qtbase_6_3_0/0034-optional-gtk.patch
+++ b/qtbase_6_3_0/0034-optional-gtk.patch
@@ -1,0 +1,609 @@
+diff --git a/src/plugins/platformthemes/gtk3/CMakeLists.txt b/src/plugins/platformthemes/gtk3/CMakeLists.txt
+index 62e752bd92..f068d91a50 100644
+--- a/src/plugins/platformthemes/gtk3/CMakeLists.txt
++++ b/src/plugins/platformthemes/gtk3/CMakeLists.txt
+@@ -16,9 +16,13 @@ qt_internal_add_plugin(QGtk3ThemePlugin
+         qgtk3dialoghelpers.cpp qgtk3dialoghelpers.h
+         qgtk3menu.cpp qgtk3menu.h
+         qgtk3theme.cpp qgtk3theme.h
++        gtk_functions.h
+     DEFINES
++        GLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_40
++        GLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_40
+         GDK_VERSION_MIN_REQUIRED=GDK_VERSION_3_6
+     LIBRARIES # special case
++        ${CMAKE_DL_LIBS}
+         PkgConfig::GTK3
+         Qt::Core
+         Qt::CorePrivate
+diff --git a/src/plugins/platformthemes/gtk3/gtk_functions.h b/src/plugins/platformthemes/gtk3/gtk_functions.h
+new file mode 100644
+index 0000000000..a4060f0e6a
+--- /dev/null
++++ b/src/plugins/platformthemes/gtk3/gtk_functions.h
+@@ -0,0 +1,358 @@
++#pragma once
++
++#include <gtk/gtk.h>
++#include <gdk/gdk.h>
++#include <gdk/gdkx.h>
++#include <pango/pango.h>
++
++#define g_free ptr_g_free
++#define g_log_default_handler ptr_g_log_default_handler
++#define g_log_set_handler ptr_g_log_set_handler
++#define g_slist_free ptr_g_slist_free
++#define g_strcmp0 ptr_g_strcmp0
++#define g_object_class_find_property ptr_g_object_class_find_property
++#define g_object_get ptr_g_object_get
++#define g_object_set ptr_g_object_set
++#define g_object_unref ptr_g_object_unref
++#define g_signal_connect_data ptr_g_signal_connect_data
++#define g_type_check_instance_cast ptr_g_type_check_instance_cast
++#define g_type_check_instance_is_a ptr_g_type_check_instance_is_a
++#define g_type_check_instance_is_fundamentally_a ptr_g_type_check_instance_is_fundamentally_a
++#define g_type_ensure ptr_g_type_ensure
++#define gdk_pixbuf_new_from_file_at_size ptr_gdk_pixbuf_new_from_file_at_size
++#define gdk_window_focus ptr_gdk_window_focus
++#define gdk_window_get_display ptr_gdk_window_get_display
++#define gdk_window_set_modal_hint ptr_gdk_window_set_modal_hint
++#define gdk_x11_display_get_xdisplay ptr_gdk_x11_display_get_xdisplay
++#define gdk_x11_window_get_type ptr_gdk_x11_window_get_type
++#define gdk_x11_window_get_xid ptr_gdk_x11_window_get_xid
++#define gtk_accel_label_get_type ptr_gtk_accel_label_get_type
++#define gtk_accel_label_set_accel ptr_gtk_accel_label_set_accel
++#define gtk_bin_get_child ptr_gtk_bin_get_child
++#define gtk_bin_get_type ptr_gtk_bin_get_type
++#define gtk_button_get_type ptr_gtk_button_get_type
++#define gtk_button_set_label ptr_gtk_button_set_label
++#define gtk_check_menu_item_get_active ptr_gtk_check_menu_item_get_active
++#define gtk_check_menu_item_get_type ptr_gtk_check_menu_item_get_type
++#define gtk_check_menu_item_new ptr_gtk_check_menu_item_new
++#define gtk_check_menu_item_set_active ptr_gtk_check_menu_item_set_active
++#define gtk_check_version ptr_gtk_check_version
++#define gtk_clipboard_get ptr_gtk_clipboard_get
++#define gtk_clipboard_store ptr_gtk_clipboard_store
++#define gtk_color_chooser_dialog_new ptr_gtk_color_chooser_dialog_new
++#define gtk_color_chooser_get_type ptr_gtk_color_chooser_get_type
++#define gtk_color_chooser_get_rgba ptr_gtk_color_chooser_get_rgba
++#define gtk_color_chooser_set_rgba ptr_gtk_color_chooser_set_rgba
++#define gtk_color_chooser_set_use_alpha ptr_gtk_color_chooser_set_use_alpha
++#define gtk_container_get_type ptr_gtk_container_get_type
++#define gtk_container_remove ptr_gtk_container_remove
++#define gtk_dialog_add_button ptr_gtk_dialog_add_button
++#define gtk_dialog_get_type ptr_gtk_dialog_get_type
++#define gtk_dialog_get_widget_for_response ptr_gtk_dialog_get_widget_for_response
++#define gtk_dialog_run ptr_gtk_dialog_run
++#define gtk_file_chooser_add_filter ptr_gtk_file_chooser_add_filter
++#define gtk_file_chooser_dialog_new ptr_gtk_file_chooser_dialog_new
++#define gtk_file_chooser_get_current_folder ptr_gtk_file_chooser_get_current_folder
++#define gtk_file_chooser_get_filename ptr_gtk_file_chooser_get_filename
++#define gtk_file_chooser_get_filenames ptr_gtk_file_chooser_get_filenames
++#define gtk_file_chooser_get_filter ptr_gtk_file_chooser_get_filter
++#define gtk_file_chooser_get_preview_filename ptr_gtk_file_chooser_get_preview_filename
++#define gtk_file_chooser_get_type ptr_gtk_file_chooser_get_type
++#define gtk_file_chooser_remove_filter ptr_gtk_file_chooser_remove_filter
++#define gtk_file_chooser_select_filename ptr_gtk_file_chooser_select_filename
++#define gtk_file_chooser_set_action ptr_gtk_file_chooser_set_action
++#define gtk_file_chooser_set_create_folders ptr_gtk_file_chooser_set_create_folders
++#define gtk_file_chooser_set_current_folder ptr_gtk_file_chooser_set_current_folder
++#define gtk_file_chooser_set_current_name ptr_gtk_file_chooser_set_current_name
++#define gtk_file_chooser_set_do_overwrite_confirmation ptr_gtk_file_chooser_set_do_overwrite_confirmation
++#define gtk_file_chooser_set_filter ptr_gtk_file_chooser_set_filter
++#define gtk_file_chooser_set_local_only ptr_gtk_file_chooser_set_local_only
++#define gtk_file_chooser_set_preview_widget ptr_gtk_file_chooser_set_preview_widget
++#define gtk_file_chooser_set_preview_widget_active ptr_gtk_file_chooser_set_preview_widget_active
++#define gtk_file_chooser_set_select_multiple ptr_gtk_file_chooser_set_select_multiple
++#define gtk_file_filter_add_pattern ptr_gtk_file_filter_add_pattern
++#define gtk_file_filter_new ptr_gtk_file_filter_new
++#define gtk_file_filter_set_name ptr_gtk_file_filter_set_name
++#define gtk_font_chooser_dialog_new ptr_gtk_font_chooser_dialog_new
++#define gtk_font_chooser_get_font ptr_gtk_font_chooser_get_font
++#define gtk_font_chooser_get_type ptr_gtk_font_chooser_get_type
++#define gtk_font_chooser_set_font ptr_gtk_font_chooser_set_font
++#define gtk_get_current_event_time ptr_gtk_get_current_event_time
++#define gtk_image_get_type ptr_gtk_image_get_type
++#define gtk_image_new ptr_gtk_image_new
++#define gtk_image_set_from_pixbuf ptr_gtk_image_set_from_pixbuf
++#define gtk_init ptr_gtk_init
++#define gtk_menu_get_type ptr_gtk_menu_get_type
++#define gtk_menu_item_get_type ptr_gtk_menu_item_get_type
++#define gtk_menu_item_new ptr_gtk_menu_item_new
++#define gtk_menu_item_set_label ptr_gtk_menu_item_set_label
++#define gtk_menu_item_set_submenu ptr_gtk_menu_item_set_submenu
++#define gtk_menu_item_set_use_underline ptr_gtk_menu_item_set_use_underline
++#define gtk_menu_new ptr_gtk_menu_new
++#define gtk_menu_popdown ptr_gtk_menu_popdown
++#define gtk_menu_popup ptr_gtk_menu_popup
++#define gtk_menu_shell_get_type ptr_gtk_menu_shell_get_type
++#define gtk_menu_shell_insert ptr_gtk_menu_shell_insert
++#define gtk_menu_shell_select_item ptr_gtk_menu_shell_select_item
++#define gtk_separator_menu_item_new ptr_gtk_separator_menu_item_new
++#define gtk_settings_get_default ptr_gtk_settings_get_default
++#define gtk_widget_destroy ptr_gtk_widget_destroy
++#define gtk_widget_get_scale_factor ptr_gtk_widget_get_scale_factor
++#define gtk_widget_get_type ptr_gtk_widget_get_type
++#define gtk_widget_get_window ptr_gtk_widget_get_window
++#define gtk_widget_hide ptr_gtk_widget_hide
++#define gtk_widget_hide_on_delete ptr_gtk_widget_hide_on_delete
++#define gtk_widget_realize ptr_gtk_widget_realize
++#define gtk_widget_set_sensitive ptr_gtk_widget_set_sensitive
++#define gtk_widget_set_visible ptr_gtk_widget_set_visible
++#define gtk_widget_show ptr_gtk_widget_show
++#define gtk_window_get_type ptr_gtk_window_get_type
++#define gtk_window_set_title ptr_gtk_window_set_title
++#define gtk_window_set_transient_for ptr_gtk_window_set_transient_for
++#define pango_font_description_free ptr_pango_font_description_free
++#define pango_font_description_from_string ptr_pango_font_description_from_string
++#define pango_font_description_get_family ptr_pango_font_description_get_family
++#define pango_font_description_get_size ptr_pango_font_description_get_size
++#define pango_font_description_get_style ptr_pango_font_description_get_style
++#define pango_font_description_get_weight ptr_pango_font_description_get_weight
++#define pango_font_description_new ptr_pango_font_description_new
++#define pango_font_description_set_family ptr_pango_font_description_set_family
++#define pango_font_description_set_size ptr_pango_font_description_set_size
++#define pango_font_description_set_style ptr_pango_font_description_set_style
++#define pango_font_description_set_weight ptr_pango_font_description_set_weight
++#define pango_font_description_to_string ptr_pango_font_description_to_string
++#define pango_font_face_get_type ptr_pango_font_face_get_type
++#define pango_font_family_get_type ptr_pango_font_family_get_type
++
++inline void (*g_free)(gpointer mem);
++inline void (*g_log_default_handler)(
++	const gchar* log_domain,
++	GLogLevelFlags log_level,
++	const gchar* message,
++	gpointer unused_data);
++inline guint (*g_log_set_handler)(
++	const gchar* log_domain,
++	GLogLevelFlags log_levels,
++	GLogFunc log_func,
++	gpointer user_data);
++inline void (*g_slist_free)(GSList* list);
++inline int (*g_strcmp0)(const char* str1, const char* str2);
++inline GParamSpec* (*g_object_class_find_property)(
++	GObjectClass* oclass,
++	const gchar* property_name);
++inline void (*g_object_get)(
++	gpointer object,
++	const gchar* first_property_name,
++	...);
++inline void (*g_object_set)(
++	gpointer object,
++	const gchar* first_property_name,
++	...);
++inline void (*g_object_unref)(gpointer object);
++inline gulong (*g_signal_connect_data)(
++	gpointer instance,
++	const gchar* detailed_signal,
++	GCallback c_handler,
++	gpointer data,
++	GClosureNotify destroy_data,
++	GConnectFlags connect_flags);
++inline GTypeInstance* (*g_type_check_instance_cast)(
++	GTypeInstance* instance,
++	GType iface_type);
++inline gboolean (*g_type_check_instance_is_a)(
++	GTypeInstance* instance,
++	GType iface_type);
++inline void (*g_type_ensure)(GType type);
++inline GdkPixbuf *(*gdk_pixbuf_new_from_file_at_size)(
++	const char *filename,
++	int width,
++	int height,
++	GError **error);
++inline void (*gdk_window_focus)(GdkWindow *window, guint32 timestamp);
++inline GdkDisplay *(*gdk_window_get_display)(GdkWindow *window);
++inline void (*gdk_window_set_modal_hint)(GdkWindow *window, gboolean modal);
++inline Display *(*gdk_x11_display_get_xdisplay)(GdkDisplay *display);
++inline GType (*gdk_x11_window_get_type)(void);
++inline Window (*gdk_x11_window_get_xid)(GdkWindow *window);
++inline GType (*gtk_accel_label_get_type)(void);
++inline void (*gtk_accel_label_set_accel)(
++	GtkAccelLabel *accel_label,
++	guint accelerator_key,
++	GdkModifierType accelerator_mods);
++inline GtkWidget *(*gtk_bin_get_child)(GtkBin *bin);
++inline GType (*gtk_bin_get_type)(void);
++inline GType (*gtk_button_get_type)(void);
++inline void (*gtk_button_set_label)(GtkButton *button, const gchar *label);
++inline gboolean (*gtk_check_menu_item_get_active)(GtkCheckMenuItem *check_menu_item);
++inline GType (*gtk_check_menu_item_get_type)(void);
++inline GtkWidget* (*gtk_check_menu_item_new)(void);
++inline void (*gtk_check_menu_item_set_active)(
++	GtkCheckMenuItem *check_menu_item,
++	gboolean is_active);
++inline const gchar *(*gtk_check_version)(
++	guint required_major,
++	guint required_minor,
++	guint required_micro);
++inline GtkClipboard *(*gtk_clipboard_get)(GdkAtom selection);
++inline void (*gtk_clipboard_store)(GtkClipboard *clipboard);
++inline GtkWidget *(*gtk_color_chooser_dialog_new)(
++	const gchar *title,
++	GtkWindow *parent);
++inline GType (*gtk_color_chooser_get_type)(void);
++inline void (*gtk_color_chooser_get_rgba)(
++	GtkColorChooser *chooser,
++	GdkRGBA *color);
++inline void (*gtk_color_chooser_set_rgba)(
++	GtkColorChooser *chooser,
++	const GdkRGBA *color);
++inline void (*gtk_color_chooser_set_use_alpha)(
++	GtkColorChooser *chooser,
++	gboolean use_alpha);
++inline GType (*gtk_container_get_type)(void);
++inline void (*gtk_container_remove)(GtkContainer *container, GtkWidget *widget);
++inline GtkWidget *(*gtk_dialog_add_button)(
++	GtkDialog *dialog,
++	const gchar *button_text,
++	gint response_id);
++inline GType (*gtk_dialog_get_type)(void);
++inline GtkWidget* (*gtk_dialog_get_widget_for_response)(
++	GtkDialog *dialog,
++	gint response_id);
++inline gint (*gtk_dialog_run)(GtkDialog *dialog);
++inline void (*gtk_file_chooser_add_filter)(
++	GtkFileChooser *chooser,
++	GtkFileFilter *filter);
++inline GtkWidget *(*gtk_file_chooser_dialog_new)(
++	const gchar *title,
++	GtkWindow *parent,
++	GtkFileChooserAction action,
++	const gchar *first_button_text,
++	...);
++inline gchar *(*gtk_file_chooser_get_current_folder)(GtkFileChooser *chooser);
++inline gchar *(*gtk_file_chooser_get_filename)(GtkFileChooser *chooser);
++inline GSList *(*gtk_file_chooser_get_filenames)(GtkFileChooser *chooser);
++inline GtkFileFilter *(*gtk_file_chooser_get_filter)(GtkFileChooser *chooser);
++inline char *(*gtk_file_chooser_get_preview_filename)(GtkFileChooser *chooser);
++inline GType (*gtk_file_chooser_get_type)(void);
++inline void (*gtk_file_chooser_remove_filter)(
++	GtkFileChooser *chooser,
++	GtkFileFilter *filter);
++inline gboolean (*gtk_file_chooser_select_filename)(
++	GtkFileChooser *chooser,
++	const char *filename);
++inline void (*gtk_file_chooser_set_action)(
++	GtkFileChooser *chooser,
++	GtkFileChooserAction action);
++inline void (*gtk_file_chooser_set_create_folders)(
++	GtkFileChooser *chooser,
++	gboolean create_folders);
++inline gboolean (*gtk_file_chooser_set_current_folder)(
++	GtkFileChooser *chooser,
++	const gchar *filename);
++inline void (*gtk_file_chooser_set_current_name)(
++	GtkFileChooser *chooser,
++	const gchar *name);
++inline void (*gtk_file_chooser_set_do_overwrite_confirmation)(
++	GtkFileChooser *chooser,
++	gboolean do_overwrite_confirmation);
++inline void (*gtk_file_chooser_set_filter)(
++	GtkFileChooser *chooser,
++	GtkFileFilter *filter);
++inline void (*gtk_file_chooser_set_local_only)(
++	GtkFileChooser *chooser,
++	gboolean local_only);
++inline void (*gtk_file_chooser_set_preview_widget)(
++	GtkFileChooser *chooser,
++	GtkWidget *preview_widget);
++inline void (*gtk_file_chooser_set_preview_widget_active)(
++	GtkFileChooser *chooser,
++	gboolean active);
++inline void (*gtk_file_chooser_set_select_multiple)(
++	GtkFileChooser *chooser,
++	gboolean select_multiple);
++inline void (*gtk_file_filter_add_pattern)(
++	GtkFileFilter *filter,
++	const gchar *pattern);
++inline GtkFileFilter *(*gtk_file_filter_new)(void);
++inline void (*gtk_file_filter_set_name)(
++	GtkFileFilter *filter,
++	const gchar *name);
++inline GtkWidget* (*gtk_font_chooser_dialog_new)(
++	const gchar *title,
++	GtkWindow *parent);
++inline gchar* (*gtk_font_chooser_get_font)(GtkFontChooser *fontchooser);
++inline GType (*gtk_font_chooser_get_type)(void);
++inline void (*gtk_font_chooser_set_font)(
++	GtkFontChooser *fontchooser,
++	const gchar *fontname);
++inline guint32 (*gtk_get_current_event_time)(void);
++inline GType (*gtk_image_get_type)(void);
++inline GtkWidget* (*gtk_image_new)(void);
++inline void (*gtk_image_set_from_pixbuf)(GtkImage *image, GdkPixbuf *pixbuf);
++inline void (*gtk_init)(int *argc, char ***argv);
++inline GType (*gtk_menu_get_type)(void);
++inline GType (*gtk_menu_item_get_type)(void);
++inline GtkWidget* (*gtk_menu_item_new)(void);
++inline void (*gtk_menu_item_set_label)(GtkMenuItem *menu_item, const gchar *label);
++inline void (*gtk_menu_item_set_submenu)(GtkMenuItem *menu_item, GtkWidget *submenu);
++inline void (*gtk_menu_item_set_use_underline)(
++	GtkMenuItem *menu_item,
++	gboolean setting);
++inline GtkWidget* (*gtk_menu_new)(void);
++inline void (*gtk_menu_popdown)(GtkMenu *menu);
++inline void (*gtk_menu_popup)(
++	GtkMenu *menu,
++	GtkWidget *parent_menu_shell,
++	GtkWidget *parent_menu_item,
++	GtkMenuPositionFunc func,
++	gpointer data,
++	guint button,
++	guint32 activate_time);
++inline GType (*gtk_menu_shell_get_type)(void);
++inline void (*gtk_menu_shell_insert)(
++	GtkMenuShell *menu_shell,
++	GtkWidget *child,
++	gint position);
++inline void (*gtk_menu_shell_select_item)(
++	GtkMenuShell *menu_shell,
++	GtkWidget *menu_item);
++inline GtkWidget* (*gtk_separator_menu_item_new)(void);
++inline GtkSettings* (*gtk_settings_get_default)(void);
++inline void (*gtk_widget_destroy)(GtkWidget *widget);
++inline gint (*gtk_widget_get_scale_factor)(GtkWidget *widget);
++inline GType (*gtk_widget_get_type)(void);
++inline GdkWindow *(*gtk_widget_get_window)(GtkWidget *widget);
++inline void (*gtk_widget_hide)(GtkWidget *widget);
++inline gboolean (*gtk_widget_hide_on_delete)(GtkWidget *widget);
++inline void (*gtk_widget_realize)(GtkWidget *widget);
++inline void (*gtk_widget_set_sensitive)(GtkWidget *widget, gboolean sensitive);
++inline void (*gtk_widget_set_visible)(GtkWidget *widget, gboolean visible);
++inline void (*gtk_widget_show)(GtkWidget *widget);
++inline GType (*gtk_window_get_type)(void);
++inline void (*gtk_window_set_title)(GtkWindow *window, const gchar *title);
++inline void (*gtk_window_set_transient_for)(GtkWindow *window, GtkWindow *parent);
++inline void (*pango_font_description_free)(PangoFontDescription *desc);
++inline PangoFontDescription *(*pango_font_description_from_string)(const char *str);
++inline const char *(*pango_font_description_get_family)(
++	const PangoFontDescription *desc);
++inline gint (*pango_font_description_get_size)(const PangoFontDescription *desc);
++inline PangoStyle (*pango_font_description_get_style)(
++	const PangoFontDescription *desc);
++inline PangoWeight (*pango_font_description_get_weight)(
++	const PangoFontDescription *desc);
++inline PangoFontDescription *(*pango_font_description_new)(void);
++inline void (*pango_font_description_set_family)(
++	PangoFontDescription *desc,
++	const char *family);
++inline void (*pango_font_description_set_size)(
++	PangoFontDescription *desc,
++	gint size);
++inline void (*pango_font_description_set_style)(
++	PangoFontDescription *desc,
++	PangoStyle style);
++inline void (*pango_font_description_set_weight)(
++	PangoFontDescription *desc,
++	PangoWeight weight);
++inline char *(*pango_font_description_to_string)(const PangoFontDescription *desc);
++inline GType (*pango_font_face_get_type)(void);
++inline GType (*pango_font_family_get_type)(void);
+diff --git a/src/plugins/platformthemes/gtk3/main.cpp b/src/plugins/platformthemes/gtk3/main.cpp
+index 860fc3a26e..184d15e8e9 100644
+--- a/src/plugins/platformthemes/gtk3/main.cpp
++++ b/src/plugins/platformthemes/gtk3/main.cpp
+@@ -40,8 +40,174 @@
+ #include <qpa/qplatformthemeplugin.h>
+ #include "qgtk3theme.h"
+ 
++#undef signals
++#include "gtk_functions.h"
++
++#include <dlfcn.h>
++#include <memory>
++#include <iostream>
++
++#define LOAD_SYMBOL(handle, func) LoadSymbol(handle, #func, func)
++
+ QT_BEGIN_NAMESPACE
+ 
++namespace {
++
++struct HandleDeleter {
++	void operator()(void *handle) {
++		dlclose(handle);
++	}
++};
++
++using Handle = std::unique_ptr<void, HandleDeleter>;
++
++bool LoadLibrary(Handle &handle, const char *name) {
++	handle = Handle(dlopen(name, RTLD_LAZY | RTLD_NODELETE));
++	if (handle) {
++		return true;
++	}
++	std::cerr << dlerror() << std::endl;
++	return false;
++}
++
++template <typename Function>
++inline bool LoadSymbol(const Handle &handle, const char *name, Function &func) {
++	func = handle
++		? reinterpret_cast<Function>(dlsym(handle.get(), name))
++		: nullptr;
++	if (const auto error = dlerror()) {
++		std::cerr << error << std::endl;
++	}
++	return (func != nullptr);
++}
++
++bool ResolveGtk() {
++	static const auto loaded = [&] {
++		auto lib = Handle();
++		return LoadLibrary(lib, "libgtk-3.so.0")
++			&& LOAD_SYMBOL(lib, g_free)
++			&& LOAD_SYMBOL(lib, g_log_default_handler)
++			&& LOAD_SYMBOL(lib, g_log_set_handler)
++			&& LOAD_SYMBOL(lib, g_slist_free)
++			&& LOAD_SYMBOL(lib, g_strcmp0)
++			&& LOAD_SYMBOL(lib, g_object_class_find_property)
++			&& LOAD_SYMBOL(lib, g_object_get)
++			&& LOAD_SYMBOL(lib, g_object_set)
++			&& LOAD_SYMBOL(lib, g_object_unref)
++			&& LOAD_SYMBOL(lib, g_signal_connect_data)
++			&& LOAD_SYMBOL(lib, g_type_check_instance_cast)
++			&& LOAD_SYMBOL(lib, g_type_check_instance_is_a)
++			&& LOAD_SYMBOL(lib, g_type_ensure)
++			&& LOAD_SYMBOL(lib, gdk_pixbuf_new_from_file_at_size)
++			&& LOAD_SYMBOL(lib, gdk_window_focus)
++			&& LOAD_SYMBOL(lib, gdk_window_get_display)
++			&& LOAD_SYMBOL(lib, gdk_window_set_modal_hint)
++			&& LOAD_SYMBOL(lib, gdk_x11_display_get_xdisplay)
++			&& LOAD_SYMBOL(lib, gdk_x11_window_get_type)
++			&& LOAD_SYMBOL(lib, gdk_x11_window_get_xid)
++			&& LOAD_SYMBOL(lib, gtk_accel_label_get_type)
++			&& LOAD_SYMBOL(lib, gtk_accel_label_set_accel)
++			&& LOAD_SYMBOL(lib, gtk_bin_get_child)
++			&& LOAD_SYMBOL(lib, gtk_bin_get_type)
++			&& LOAD_SYMBOL(lib, gtk_button_get_type)
++			&& LOAD_SYMBOL(lib, gtk_button_set_label)
++			&& LOAD_SYMBOL(lib, gtk_check_menu_item_get_active)
++			&& LOAD_SYMBOL(lib, gtk_check_menu_item_get_type)
++			&& LOAD_SYMBOL(lib, gtk_check_menu_item_new)
++			&& LOAD_SYMBOL(lib, gtk_check_menu_item_set_active)
++			&& LOAD_SYMBOL(lib, gtk_check_version)
++			&& LOAD_SYMBOL(lib, gtk_clipboard_get)
++			&& LOAD_SYMBOL(lib, gtk_clipboard_store)
++			&& LOAD_SYMBOL(lib, gtk_color_chooser_dialog_new)
++			&& LOAD_SYMBOL(lib, gtk_color_chooser_get_rgba)
++			&& LOAD_SYMBOL(lib, gtk_color_chooser_get_type)
++			&& LOAD_SYMBOL(lib, gtk_color_chooser_set_rgba)
++			&& LOAD_SYMBOL(lib, gtk_color_chooser_set_use_alpha)
++			&& LOAD_SYMBOL(lib, gtk_container_get_type)
++			&& LOAD_SYMBOL(lib, gtk_container_remove)
++			&& LOAD_SYMBOL(lib, gtk_dialog_add_button)
++			&& LOAD_SYMBOL(lib, gtk_dialog_get_type)
++			&& LOAD_SYMBOL(lib, gtk_dialog_get_widget_for_response)
++			&& LOAD_SYMBOL(lib, gtk_dialog_run)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_add_filter)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_dialog_new)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_get_current_folder)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_get_filename)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_get_filenames)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_get_filter)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_get_preview_filename)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_get_type)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_remove_filter)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_select_filename)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_set_action)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_set_create_folders)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_set_current_folder)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_set_current_name)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_set_do_overwrite_confirmation)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_set_filter)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_set_local_only)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_set_preview_widget)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_set_preview_widget_active)
++			&& LOAD_SYMBOL(lib, gtk_file_chooser_set_select_multiple)
++			&& LOAD_SYMBOL(lib, gtk_file_filter_add_pattern)
++			&& LOAD_SYMBOL(lib, gtk_file_filter_new)
++			&& LOAD_SYMBOL(lib, gtk_file_filter_set_name)
++			&& LOAD_SYMBOL(lib, gtk_font_chooser_dialog_new)
++			&& LOAD_SYMBOL(lib, gtk_font_chooser_get_font)
++			&& LOAD_SYMBOL(lib, gtk_font_chooser_get_type)
++			&& LOAD_SYMBOL(lib, gtk_font_chooser_set_font)
++			&& LOAD_SYMBOL(lib, gtk_get_current_event_time)
++			&& LOAD_SYMBOL(lib, gtk_image_get_type)
++			&& LOAD_SYMBOL(lib, gtk_image_new)
++			&& LOAD_SYMBOL(lib, gtk_image_set_from_pixbuf)
++			&& LOAD_SYMBOL(lib, gtk_init)
++			&& LOAD_SYMBOL(lib, gtk_menu_get_type)
++			&& LOAD_SYMBOL(lib, gtk_menu_item_get_type)
++			&& LOAD_SYMBOL(lib, gtk_menu_item_new)
++			&& LOAD_SYMBOL(lib, gtk_menu_item_set_label)
++			&& LOAD_SYMBOL(lib, gtk_menu_item_set_submenu)
++			&& LOAD_SYMBOL(lib, gtk_menu_item_set_use_underline)
++			&& LOAD_SYMBOL(lib, gtk_menu_new)
++			&& LOAD_SYMBOL(lib, gtk_menu_popdown)
++			&& LOAD_SYMBOL(lib, gtk_menu_popup)
++			&& LOAD_SYMBOL(lib, gtk_menu_shell_get_type)
++			&& LOAD_SYMBOL(lib, gtk_menu_shell_insert)
++			&& LOAD_SYMBOL(lib, gtk_menu_shell_select_item)
++			&& LOAD_SYMBOL(lib, gtk_separator_menu_item_new)
++			&& LOAD_SYMBOL(lib, gtk_settings_get_default)
++			&& LOAD_SYMBOL(lib, gtk_widget_destroy)
++			&& LOAD_SYMBOL(lib, gtk_widget_get_scale_factor)
++			&& LOAD_SYMBOL(lib, gtk_widget_get_type)
++			&& LOAD_SYMBOL(lib, gtk_widget_get_window)
++			&& LOAD_SYMBOL(lib, gtk_widget_hide)
++			&& LOAD_SYMBOL(lib, gtk_widget_hide_on_delete)
++			&& LOAD_SYMBOL(lib, gtk_widget_realize)
++			&& LOAD_SYMBOL(lib, gtk_widget_set_sensitive)
++			&& LOAD_SYMBOL(lib, gtk_widget_set_visible)
++			&& LOAD_SYMBOL(lib, gtk_widget_show)
++			&& LOAD_SYMBOL(lib, gtk_window_get_type)
++			&& LOAD_SYMBOL(lib, gtk_window_set_title)
++			&& LOAD_SYMBOL(lib, gtk_window_set_transient_for)
++			&& LOAD_SYMBOL(lib, pango_font_description_free)
++			&& LOAD_SYMBOL(lib, pango_font_description_from_string)
++			&& LOAD_SYMBOL(lib, pango_font_description_get_family)
++			&& LOAD_SYMBOL(lib, pango_font_description_get_size)
++			&& LOAD_SYMBOL(lib, pango_font_description_get_style)
++			&& LOAD_SYMBOL(lib, pango_font_description_get_weight)
++			&& LOAD_SYMBOL(lib, pango_font_description_new)
++			&& LOAD_SYMBOL(lib, pango_font_description_set_family)
++			&& LOAD_SYMBOL(lib, pango_font_description_set_size)
++			&& LOAD_SYMBOL(lib, pango_font_description_set_style)
++			&& LOAD_SYMBOL(lib, pango_font_description_set_weight)
++			&& LOAD_SYMBOL(lib, pango_font_description_to_string)
++			&& LOAD_SYMBOL(lib, pango_font_face_get_type)
++			&& LOAD_SYMBOL(lib, pango_font_family_get_type);
++	}();
++	return loaded;
++}
++
++} // namespace
++
+ class QGtk3ThemePlugin : public QPlatformThemePlugin
+ {
+    Q_OBJECT
+@@ -54,7 +220,7 @@ public:
+ QPlatformTheme *QGtk3ThemePlugin::create(const QString &key, const QStringList &params)
+ {
+     Q_UNUSED(params);
+-    if (!key.compare(QLatin1String(QGtk3Theme::name), Qt::CaseInsensitive))
++    if (!key.compare(QLatin1String(QGtk3Theme::name), Qt::CaseInsensitive) && ResolveGtk())
+         return new QGtk3Theme;
+ 
+     return nullptr;
+diff --git a/src/plugins/platformthemes/gtk3/qgtk3dialoghelpers.cpp b/src/plugins/platformthemes/gtk3/qgtk3dialoghelpers.cpp
+index 4f417d77d8..c0ef445b0f 100644
+--- a/src/plugins/platformthemes/gtk3/qgtk3dialoghelpers.cpp
++++ b/src/plugins/platformthemes/gtk3/qgtk3dialoghelpers.cpp
+@@ -56,6 +56,8 @@
+ #include <gdk/gdkx.h>
+ #include <pango/pango.h>
+ 
++#include "gtk_functions.h"
++
+ // The size of the preview we display for selected image files. We set height
+ // larger than width because generally there is more free space vertically
+ // than horiztonally (setting the preview image will alway expand the width of
+diff --git a/src/plugins/platformthemes/gtk3/qgtk3menu.cpp b/src/plugins/platformthemes/gtk3/qgtk3menu.cpp
+index 3e00d9610f..1d366a0005 100644
+--- a/src/plugins/platformthemes/gtk3/qgtk3menu.cpp
++++ b/src/plugins/platformthemes/gtk3/qgtk3menu.cpp
+@@ -46,6 +46,8 @@
+ #undef signals
+ #include <gtk/gtk.h>
+ 
++#include "gtk_functions.h"
++
+ QT_BEGIN_NAMESPACE
+ 
+ #if QT_CONFIG(shortcut)
+diff --git a/src/plugins/platformthemes/gtk3/qgtk3theme.cpp b/src/plugins/platformthemes/gtk3/qgtk3theme.cpp
+index a47720384c..e768ea4d3e 100644
+--- a/src/plugins/platformthemes/gtk3/qgtk3theme.cpp
++++ b/src/plugins/platformthemes/gtk3/qgtk3theme.cpp
+@@ -48,6 +48,8 @@
+ 
+ #include <X11/Xlib.h>
+ 
++#include "gtk_functions.h"
++
+ QT_BEGIN_NAMESPACE
+ 
+ const char *QGtk3Theme::name = "gtk3";

--- a/qtbase_6_3_0/0035-fix-glitching-emoji-cursor.patch
+++ b/qtbase_6_3_0/0035-fix-glitching-emoji-cursor.patch
@@ -1,0 +1,20 @@
+diff --git a/src/gui/text/qtextlayout.cpp b/src/gui/text/qtextlayout.cpp
+index 03eaa9c726..bab573b625 100644
+--- a/src/gui/text/qtextlayout.cpp
++++ b/src/gui/text/qtextlayout.cpp
+@@ -1309,12 +1309,15 @@ void QTextLayout::drawCursor(QPainter *p, const QPointF &pos, int cursorPosition
+                 si = &d->layoutData->items[itm];
+             }
+         }
++        // Patch: Use line geometry, otherwise smiles get glitching cursor.
++#if 0
+         if (si->ascent >= 0)
+             base = si->ascent;
+         if (si->descent == 0)
+             descent = si->descent;
+         else if (si->descent > 0 && si->descent < descent)
+             cursorDescent = si->descent;
++#endif
+         rightToLeft = si->analysis.bidiLevel % 2;
+     }
+     qreal y = position.y() + (sl.y + sl.base() + sl.descent - base - descent).toReal();

--- a/qtbase_6_3_0/0036-fix-opengl-crash-on-context-loss.patch
+++ b/qtbase_6_3_0/0036-fix-opengl-crash-on-context-loss.patch
@@ -1,0 +1,14 @@
+diff --git a/src/opengl/qopenglpaintengine.cpp b/src/opengl/qopenglpaintengine.cpp
+index f835019136..30553804d8 100644
+--- a/src/opengl/qopenglpaintengine.cpp
++++ b/src/opengl/qopenglpaintengine.cpp
+@@ -2167,7 +2167,8 @@ bool QOpenGL2PaintEngineEx::begin(QPaintDevice *pdev)
+ 
+     d->device->ensureActiveTarget();
+ 
+-    if (d->device->context() != QOpenGLContext::currentContext() || !d->device->context()) {
++    if (!QOpenGLContext::currentContext() || d->device->context() != QOpenGLContext::currentContext()
++        || !d->device->context()) {
+         qWarning("QPainter::begin(): QOpenGLPaintDevice's context needs to be current");
+         return false;
+     }

--- a/qtbase_6_3_0/0037-fix-build-on-centos-7.patch
+++ b/qtbase_6_3_0/0037-fix-build-on-centos-7.patch
@@ -1,0 +1,14 @@
+diff --git a/src/corelib/plugin/qelfparser_p.cpp b/src/corelib/plugin/qelfparser_p.cpp
+index c6ccda92fb..def1e2494a 100644
+--- a/src/corelib/plugin/qelfparser_p.cpp
++++ b/src/corelib/plugin/qelfparser_p.cpp
+@@ -409,7 +409,9 @@ Q_DECL_UNUSED Q_DECL_COLD_FUNCTION static QDebug &operator<<(QDebug &d, ElfHeade
+     case EM_NONE:       d << ", no machine"; break;
+     case EM_ARM:        d << ", ARM"; break;
+     case EM_AARCH64:    d << ", AArch64"; break;
++#ifdef EM_BLACKFIN
+     case EM_BLACKFIN:   d << ", Blackfin"; break;
++#endif
+     case EM_IA_64:      d << ", IA-64"; break;
+     case EM_MIPS:       d << ", MIPS"; break;
+     case EM_PPC:        d << ", PowerPC"; break;


### PR DESCRIPTION
Removed patches:
* qt-patched-define: is not used for a long time
* add-preview-support-to-gtk-file-dialog: upstreamed
* fix-crash-in-network-reply-finished: it shouldn't have any sense since 6.0 since the code between guard uses was removed
* workaround-crash-text-engine: should be fixed by https://codereview.qt-project.org/c/qt/qtbase/+/390159
* allow-startsystemmoveresize-on-unity: there doesn't seem to be any check for Unity anymore...
* fix-open-macos-window-ghost-focused-after-popup: https://codereview.qt-project.org/c/qt/qtbase/+/373763
* epoxy: the snapd bug was fixed, so this shouldn't be needed anymore
* optional-glib: well, we don't really use it
* no-xcb-xinput-warning: they don't use system xcb-xinput by default anymore
* fix-frameless-translucent-macos: was backported from 6.3
* check-shellintegration: Chrome OS supports xdg-shell now, so I hope we don't need this patch anymore

Added patches:
* fix-build-on-centos-7: Fix build on CentOS 7