### PR TITLE
Enable AV1 decoding via dav1d on Windows

### DIFF
--- a/build_ffmpeg_win.sh
+++ b/build_ffmpeg_win.sh
@@ -42,6 +42,7 @@ export PKG_CONFIG_PATH="$FullExecPath/../local/lib/pkgconfig:$PKG_CONFIG_PATH"
 --enable-hwaccel=mpeg4_nvdec \
 --enable-hwaccel=vp8_nvdec \
 --enable-protocol=file \
+--enable-libdav1d \
 --enable-libopus \
 --enable-libvpx \
 --enable-decoder=aac \
@@ -57,6 +58,7 @@ export PKG_CONFIG_PATH="$FullExecPath/../local/lib/pkgconfig:$PKG_CONFIG_PATH"
 --enable-decoder=gif \
 --enable-decoder=h264 \
 --enable-decoder=hevc \
+--enable-decoder=libdav1d \
 --enable-decoder=libvpx_vp8 \
 --enable-decoder=libvpx_vp9 \
 --enable-decoder=mp1 \


### PR DESCRIPTION
There is already dav1d library in Windows build of Telegram, but support was not enabled in ffmpeg.

With this simple patch, Telegram will be able to play movies like 
[test_movie.zip](https://github.com/desktop-app/patches/files/10295218/test_movie.zip)
