### PR TITLE
Fix QWidget::set{Minimum,Maximum}Size API guarantees

### DIFF
--- a/qtbase_6.5.0/0030-fix-qwidget-api-guarantees.patch
+++ b/qtbase_6.5.0/0030-fix-qwidget-api-guarantees.patch
@@ -1,0 +1,19 @@
+diff --git a/src/widgets/kernel/qwidgetwindow.cpp b/src/widgets/kernel/qwidgetwindow.cpp
+index 7756893369..fe12fe8b0f 100644
+--- a/src/widgets/kernel/qwidgetwindow.cpp
++++ b/src/widgets/kernel/qwidgetwindow.cpp
+@@ -677,9 +677,12 @@ bool QWidgetWindow::updateSize()
+     if (m_widget->testAttribute(Qt::WA_DontShowOnScreen))
+         return changed;
+ 
+-    if (m_widget->data->crect.size() != geometry().size()) {
++    QWExtra *extra = m_widget->d_func()->extraData();
++    QSize boundedSize(qBound(extra->minw, geometry().width(), extra->maxw),
++                      qBound(extra->minh, geometry().height(), extra->maxh));
++    if (m_widget->data->crect.size() != boundedSize) {
+         changed = true;
+-        m_widget->data->crect.setSize(geometry().size());
++        m_widget->data->crect.setSize(boundedSize);
+     }
+ 
+     updateMargins();


### PR DESCRIPTION
According to the documentation, minimum size is enforced, but this doesn't in fact happen for top-level widgets what breaks tdesktop expectations and leads to crashes. This patch makes Qt behavior in line with the documentation to avoid the crashes with tiling window managers that don't respect minimum window size.