### PR TITLE
Fix libvpx build on VS 17.8+

### DIFF
--- a/build_libvpx_win.sh
+++ b/build_libvpx_win.sh
@@ -9,7 +9,7 @@ pacman --noconfirm -S msys/make
 pacman --noconfirm -S diffutils
 
 ./configure --prefix=$FullScriptPath/../local \
---target=$TARGET \
+--target=$TOOLCHAIN \
 --disable-examples \
 --disable-unit-tests \
 --disable-tools \


### PR DESCRIPTION
Use TOOLCHAIN instead of TARGET variable name to avoid conflict
see https://github.com/telegramdesktop/tdesktop/issues/26012 for more details