### PR TITLE
Don't require an action interface for UIA SelectionContainer.

### DIFF
--- a/qtbase_5.15.19/0035-fix-uia-selection-container-no-action-interface.patch
+++ b/qtbase_5.15.19/0035-fix-uia-selection-container-no-action-interface.patch
@@ -1,0 +1,15 @@
+diff --git a/src/plugins/platforms/windows/uiautomation/qwindowsuiaselectionitemprovider.cpp b/src/plugins/platforms/windows/uiautomation/qwindowsuiaselectionitemprovider.cpp
+index 30e9524d54e..71e417c90d6 100644
+--- a/src/plugins/platforms/windows/uiautomation/qwindowsuiaselectionitemprovider.cpp
++++ b/src/plugins/platforms/windows/uiautomation/qwindowsuiaselectionitemprovider.cpp
+@@ -180,10 +180,6 @@ HRESULT STDMETHODCALLTYPE QWindowsUiaSelectionItemProvider::get_SelectionContain
+     if (!accessible)
+         return UIA_E_ELEMENTNOTAVAILABLE;
+ 
+-    QAccessibleActionInterface *actionInterface = accessible->actionInterface();
+-    if (!actionInterface)
+-        return UIA_E_ELEMENTNOTAVAILABLE;
+-
+     // Radio buttons do not require a container.
+     if (accessible->role() == QAccessible::ListItem) {
+         if (QAccessibleInterface *parent = accessible->parent()) {


### PR DESCRIPTION
### What

Adds `qtbase_5.15.19/0035-fix-uia-selection-container-no-action-interface.patch`, which removes an unnecessary `actionInterface()` requirement from `QWindowsUiaSelectionItemProvider::get_SelectionContainer`. The check causes the method to return `UIA_E_ELEMENTNOTAVAILABLE` for any `ListItem`-role accessible whose `QAccessibleInterface` does not implement an action interface — even though the function never actually calls `actionInterface->doAction(...)`. The check is dead weight that breaks legitimate accessibles.

### Why

In Telegram Desktop's chat list (`Dialogs::InnerWidget`), the per-row accessibles exposed by `lib_ui::Ui::Accessible::Item` provide name / role / state / rect but no action interface. Qt's UIA bridge auto-exposes `SelectionItemPattern` on every `ListItem`-role element (see `qwindowsuiamainprovider.cpp:340-346`), so screen readers query `SelectionContainer` on them. With this check in place, Qt returns the error, and NVDA's `_get_selectionContainer` raises a `COMError` from `IUIAutomationSelectionItemPattern::CurrentSelectionContainer`. The exception propagates up through `reportFocus → speakObject → getObjectPropertiesSpeech` (triggered by the `SELECTABLE | FOCUSABLE | SELECTED` branch in NVDA's `speech.py`), aborting speech for the entire focus event. Users hear nothing when arrowing through the chat list.

A parallel NVDA-side defensive fix is in flight at nvaccess/nvda#20255, but the underlying Qt bug is real and worth fixing at the source — it affects any UIA client (not just NVDA) that touches this property on tdesktop's chat list or any other Qt list whose items don't have actions.

### How

`get_SelectionContainer` never calls `actionInterface->doAction(...)`. Removing the check is safe — the function still returns `S_OK` with `*pRetVal = nullptr` for elements that don't satisfy the subsequent role/parent conditions, which matches its documented contract. The other methods in the file (`Select`, `AddToSelection`, `RemoveFromSelection`) still need the check and are unchanged.

### Upstream status

The same bug still exists in Qt 6 (verified against the `6.8` release branch and `dev`). Qt 6 added a fast path that returns early when the parent implements `selectionInterface()`, but the broken `actionInterface` check is still reachable for accessibles whose parent doesn't expose a selection interface — including tdesktop's chat list. So the same fix would be useful for `qtbase_6.11.1` / `qtbase_6.2.13` if tdesktop migrates; this PR only patches the version currently in use (5.15.19).

### Testing

- **Repro**: Telegram Desktop with the current 5.15.19 build, NVDA running, focus the chat list and arrow up/down. Without the patch, no row is spoken — only the navigation review commands (NVDA+numpad6/4) work.
- **With this patch applied**: rebuilt only the `qwindows` platform plugin (the changed .cpp lives in `src/plugins/platforms/windows/uiautomation`). After replacing the plugin, every row is spoken on focus as expected.