### PR TITLE
Backport UIA selection + orientation interfaces for custom tab controls

### DIFF
--- a/qtbase_5.15.19/0037-backport-uia-selection-interface.patch
+++ b/qtbase_5.15.19/0037-backport-uia-selection-interface.patch
@@ -1,0 +1,278 @@
+diff --git a/src/gui/accessible/qaccessible.h b/src/gui/accessible/qaccessible.h
+index f7564a3076b..1cdbaaa8af2 100644
+--- a/src/gui/accessible/qaccessible.h
++++ b/src/gui/accessible/qaccessible.h
+@@ -380,7 +380,8 @@ public:
+         ActionInterface,
+         ImageInterface,
+         TableInterface,
+-        TableCellInterface
++        TableCellInterface,
++        SelectionInterface
+     };
+ 
+     enum TextBoundaryType {
+@@ -453,6 +454,7 @@ class QAccessibleActionInterface;
+ class QAccessibleImageInterface;
+ class QAccessibleTableInterface;
+ class QAccessibleTableCellInterface;
++class QAccessibleSelectionInterface;
+ class QAccessibleTableModelChangeEvent;
+ 
+ class Q_GUI_EXPORT QAccessibleInterface
+@@ -509,6 +511,9 @@ public:
+     inline QAccessibleTableCellInterface *tableCellInterface()
+     { return reinterpret_cast<QAccessibleTableCellInterface *>(interface_cast(QAccessible::TableCellInterface)); }
+ 
++    inline QAccessibleSelectionInterface *selectionInterface()
++    { return reinterpret_cast<QAccessibleSelectionInterface *>(interface_cast(QAccessible::SelectionInterface)); }
++
+     virtual void virtual_hook(int id, void *data);
+ 
+     virtual void *interface_cast(QAccessible::InterfaceType)
+@@ -660,6 +665,21 @@ public:
+     virtual QPoint imagePosition() const = 0;
+ };
+ 
++class Q_GUI_EXPORT QAccessibleSelectionInterface
++{
++public:
++    virtual ~QAccessibleSelectionInterface();
++
++    virtual int selectedItemCount() const = 0;
++    virtual QList<QAccessibleInterface*> selectedItems() const = 0;
++    virtual QAccessibleInterface *selectedItem(int selectionIndex) const;
++    virtual bool isSelected(QAccessibleInterface *childItem) const;
++    virtual bool select(QAccessibleInterface *childItem) = 0;
++    virtual bool unselect(QAccessibleInterface *childItem) = 0;
++    virtual bool selectAll() = 0;
++    virtual bool clear() = 0;
++};
++
+ 
+ class Q_GUI_EXPORT QAccessibleEvent
+ {
+diff --git a/src/gui/accessible/qaccessible.cpp b/src/gui/accessible/qaccessible.cpp
+index 32d0e6ca91c..92af94e350f 100644
+--- a/src/gui/accessible/qaccessible.cpp
++++ b/src/gui/accessible/qaccessible.cpp
+@@ -2493,6 +2493,45 @@ QAccessibleImageInterface::~QAccessibleImageInterface()
+     // must be empty until ### Qt 6
+ }
+ 
++/*!
++    \class QAccessibleSelectionInterface
++    \inmodule QtGui
++    \ingroup accessibility
++    \internal
++
++    \brief The QAccessibleSelectionInterface class implements support for
++    reporting the selection of an accessible object (backported from Qt 6 so
++    UI Automation can resolve the selected item independently of focus).
++*/
++
++/*!
++    Destroys the QAccessibleSelectionInterface.
++*/
++QAccessibleSelectionInterface::~QAccessibleSelectionInterface()
++{
++}
++
++/*!
++    Returns the selected item at \a selectionIndex, or \nullptr if it is out of
++    range. The default implementation indexes into selectedItems().
++*/
++QAccessibleInterface *QAccessibleSelectionInterface::selectedItem(int selectionIndex) const
++{
++    const QList<QAccessibleInterface*> items = selectedItems();
++    if (selectionIndex < 0 || selectionIndex >= items.size())
++        return nullptr;
++    return items.at(selectionIndex);
++}
++
++/*!
++    Returns whether \a childItem is part of the current selection. The default
++    implementation checks whether it is contained in selectedItems().
++*/
++bool QAccessibleSelectionInterface::isSelected(QAccessibleInterface *childItem) const
++{
++    return selectedItems().contains(childItem);
++}
++
+ /*!
+     \class QAccessibleTableCellInterface
+     \inmodule QtGui
+diff --git a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
+index 403c45cefc0..8eb9820dc8f 100644
+--- a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
++++ b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
+@@ -332,14 +332,16 @@ HRESULT QWindowsUiaMainProvider::GetPatternProvider(PATTERNID idPattern, IUnknow
+             *pRetVal = new QWindowsUiaToggleProvider(id());
+         break;
+     case UIA_SelectionPatternId:
+-        // Lists of items.
+-        if (accessible->role() == QAccessible::List) {
++        // Lists of items (and any element exposing a selection interface).
++        if (accessible->selectionInterface()
++                || (accessible->role() == QAccessible::List)) {
+             *pRetVal = new QWindowsUiaSelectionProvider(id());
+         }
+         break;
+     case UIA_SelectionItemPatternId:
+-        // Items within a list and radio buttons.
+-        if ((accessible->role() == QAccessible::RadioButton)
++        // Items within a list, radio buttons, and children of a selection container.
++        if ((accessible->parent() && accessible->parent()->selectionInterface())
++                || (accessible->role() == QAccessible::RadioButton)
+                 || (accessible->role() == QAccessible::ListItem)) {
+             *pRetVal = new QWindowsUiaSelectionItemProvider(id());
+         }
+diff --git a/src/plugins/platforms/windows/uiautomation/qwindowsuiaselectionitemprovider.cpp b/src/plugins/platforms/windows/uiautomation/qwindowsuiaselectionitemprovider.cpp
+index 71e417c..ffead41 100644
+--- a/src/plugins/platforms/windows/uiautomation/qwindowsuiaselectionitemprovider.cpp
++++ b/src/plugins/platforms/windows/uiautomation/qwindowsuiaselectionitemprovider.cpp
+@@ -72,6 +72,16 @@ HRESULT STDMETHODCALLTYPE QWindowsUiaSelectionItemProvider::Select()
+     if (!accessible)
+         return UIA_E_ELEMENTNOTAVAILABLE;
+ 
++    // Prefer the container's selection interface when present (backport of
++    // Qt 6 behaviour); fall back to role-based actions otherwise.
++    if (QAccessibleInterface *parent = accessible->parent()) {
++        if (QAccessibleSelectionInterface *selectionInterface = parent->selectionInterface()) {
++            selectionInterface->clear();
++            const bool ok = selectionInterface->select(accessible);
++            return ok ? S_OK : S_FALSE;
++        }
++    }
++
+     QAccessibleActionInterface *actionInterface = accessible->actionInterface();
+     if (!actionInterface)
+         return UIA_E_ELEMENTNOTAVAILABLE;
+@@ -109,6 +119,13 @@ HRESULT STDMETHODCALLTYPE QWindowsUiaSelectionItemProvider::AddToSelection()
+     if (!accessible)
+         return UIA_E_ELEMENTNOTAVAILABLE;
+ 
++    if (QAccessibleInterface *parent = accessible->parent()) {
++        if (QAccessibleSelectionInterface *selectionInterface = parent->selectionInterface()) {
++            const bool ok = selectionInterface->select(accessible);
++            return ok ? S_OK : S_FALSE;
++        }
++    }
++
+     QAccessibleActionInterface *actionInterface = accessible->actionInterface();
+     if (!actionInterface)
+         return UIA_E_ELEMENTNOTAVAILABLE;
+@@ -134,6 +151,13 @@ HRESULT STDMETHODCALLTYPE QWindowsUiaSelectionItemProvider::RemoveFromSelection(
+     if (!accessible)
+         return UIA_E_ELEMENTNOTAVAILABLE;
+ 
++    if (QAccessibleInterface *parent = accessible->parent()) {
++        if (QAccessibleSelectionInterface *selectionInterface = parent->selectionInterface()) {
++            const bool ok = selectionInterface->unselect(accessible);
++            return ok ? S_OK : S_FALSE;
++        }
++    }
++
+     QAccessibleActionInterface *actionInterface = accessible->actionInterface();
+     if (!actionInterface)
+         return UIA_E_ELEMENTNOTAVAILABLE;
+@@ -160,6 +184,16 @@ HRESULT STDMETHODCALLTYPE QWindowsUiaSelectionItemProvider::get_IsSelected(BOOL
+     if (!accessible)
+         return UIA_E_ELEMENTNOTAVAILABLE;
+ 
++    // If the container exposes a selection interface, it is the source of
++    // truth for selection (backport of Qt 6 behaviour) - this is what lets a
++    // tab report selected from state().selected independently of focus.
++    if (QAccessibleInterface *parent = accessible->parent()) {
++        if (QAccessibleSelectionInterface *selectionInterface = parent->selectionInterface()) {
++            *pRetVal = selectionInterface->isSelected(accessible);
++            return S_OK;
++        }
++    }
++
+     if (accessible->role() == QAccessible::RadioButton)
+         *pRetVal = accessible->state().checked;
+     else
+@@ -181,11 +215,11 @@ HRESULT STDMETHODCALLTYPE QWindowsUiaSelectionItemProvider::get_SelectionContain
+         return UIA_E_ELEMENTNOTAVAILABLE;
+ 
+     // Radio buttons do not require a container.
+-    if (accessible->role() == QAccessible::ListItem) {
+-        if (QAccessibleInterface *parent = accessible->parent()) {
+-            if (parent->role() == QAccessible::List) {
+-                *pRetVal = QWindowsUiaMainProvider::providerForAccessible(parent); // Detach
+-            }
++    if (QAccessibleInterface *parent = accessible->parent()) {
++        if (parent->selectionInterface()
++                || (accessible->role() == QAccessible::ListItem
++                    && parent->role() == QAccessible::List)) {
++            *pRetVal = QWindowsUiaMainProvider::providerForAccessible(parent); // Detach
+         }
+     }
+     return S_OK;
+diff --git a/src/plugins/platforms/windows/uiautomation/qwindowsuiaselectionprovider.cpp b/src/plugins/platforms/windows/uiautomation/qwindowsuiaselectionprovider.cpp
+index fb41012cf49..f39095bdf68 100644
+--- a/src/plugins/platforms/windows/uiautomation/qwindowsuiaselectionprovider.cpp
++++ b/src/plugins/platforms/windows/uiautomation/qwindowsuiaselectionprovider.cpp
+@@ -80,10 +80,20 @@ HRESULT STDMETHODCALLTYPE QWindowsUiaSelectionProvider::GetSelection(SAFEARRAY *
+ 
+     // First put selected items in a list, then build a safe array with the right size.
+     QVector<QAccessibleInterface *> selectedList;
+-    for (int i = 0; i < accessible->childCount(); ++i) {
+-        if (QAccessibleInterface *child = accessible->child(i)) {
+-            if (child->state().selected) {
+-                selectedList.append(child);
++    if (QAccessibleSelectionInterface *selectionInterface = accessible->selectionInterface()) {
++        // The container reports its own selection (backport of Qt 6 behaviour).
++        const QList<QAccessibleInterface *> items = selectionInterface->selectedItems();
++        for (QAccessibleInterface *item : items) {
++            if (item) {
++                selectedList.append(item);
++            }
++        }
++    } else {
++        for (int i = 0; i < accessible->childCount(); ++i) {
++            if (QAccessibleInterface *child = accessible->child(i)) {
++                if (child->state().selected) {
++                    selectedList.append(child);
++                }
+             }
+         }
+     }
+@@ -127,18 +137,27 @@ HRESULT STDMETHODCALLTYPE QWindowsUiaSelectionProvider::get_IsSelectionRequired(
+     if (!accessible)
+         return UIA_E_ELEMENTNOTAVAILABLE;
+ 
+-    // Initially returns false if none are selected. After the first selection, it may be required.
+-    bool anySelected = false;
+-    for (int i = 0; i < accessible->childCount(); ++i) {
+-        if (QAccessibleInterface *child = accessible->child(i)) {
+-            if (child->state().selected) {
+-                anySelected = true;
+-                break;
++    if (accessible->role() == QAccessible::PageTabList) {
++        *pRetVal = TRUE;
++    } else {
++
++        // Initially returns false if none are selected. After the first selection, it may be required.
++        bool anySelected = false;
++        if (QAccessibleSelectionInterface *selectionInterface = accessible->selectionInterface()) {
++            anySelected = selectionInterface->selectedItem(0) != nullptr;
++        } else {
++            for (int i = 0; i < accessible->childCount(); ++i) {
++                if (QAccessibleInterface *child = accessible->child(i)) {
++                    if (child->state().selected) {
++                        anySelected = true;
++                        break;
++                    }
++                }
+             }
+         }
+-    }
+ 
+-    *pRetVal = anySelected && !accessible->state().multiSelectable && !accessible->state().extSelectable;
++        *pRetVal = anySelected && !accessible->state().multiSelectable && !accessible->state().extSelectable;
++    }
+     return S_OK;
+ }
+ 

--- a/qtbase_5.15.19/0038-backport-uia-attributes-orientation.patch
+++ b/qtbase_5.15.19/0038-backport-uia-attributes-orientation.patch
@@ -1,0 +1,101 @@
+diff --git a/src/gui/accessible/qaccessible.h b/src/gui/accessible/qaccessible.h
+index 1cdbaaa8af..121e519a33 100644
+--- a/src/gui/accessible/qaccessible.h
++++ b/src/gui/accessible/qaccessible.h
+@@ -381,9 +381,18 @@ public:
+         ImageInterface,
+         TableInterface,
+         TableCellInterface,
+-        SelectionInterface
++        SelectionInterface,
++        AttributesInterface
+     };
+ 
++    enum class Attribute {
++        Custom,
++        Level,
++        Locale,
++        Orientation,
++    };
++    Q_ENUM(Attribute)
++
+     enum TextBoundaryType {
+         CharBoundary,
+         WordBoundary,
+@@ -455,6 +464,7 @@ class QAccessibleImageInterface;
+ class QAccessibleTableInterface;
+ class QAccessibleTableCellInterface;
+ class QAccessibleSelectionInterface;
++class QAccessibleAttributesInterface;
+ class QAccessibleTableModelChangeEvent;
+ 
+ class Q_GUI_EXPORT QAccessibleInterface
+@@ -513,6 +523,8 @@ public:
+ 
+     inline QAccessibleSelectionInterface *selectionInterface()
+     { return reinterpret_cast<QAccessibleSelectionInterface *>(interface_cast(QAccessible::SelectionInterface)); }
++    inline QAccessibleAttributesInterface *attributesInterface()
++    { return reinterpret_cast<QAccessibleAttributesInterface *>(interface_cast(QAccessible::AttributesInterface)); }
+ 
+     virtual void virtual_hook(int id, void *data);
+ 
+@@ -681,6 +693,16 @@ public:
+ };
+ 
+ 
++class Q_GUI_EXPORT QAccessibleAttributesInterface
++{
++public:
++    virtual ~QAccessibleAttributesInterface();
++
++    virtual QList<QAccessible::Attribute> attributeKeys() const = 0;
++    virtual QVariant attributeValue(QAccessible::Attribute key) const = 0;
++};
++
++
+ class Q_GUI_EXPORT QAccessibleEvent
+ {
+     Q_DISABLE_COPY(QAccessibleEvent)
+diff --git a/src/gui/accessible/qaccessible.cpp b/src/gui/accessible/qaccessible.cpp
+index 92af94e350..aad625ad89 100644
+--- a/src/gui/accessible/qaccessible.cpp
++++ b/src/gui/accessible/qaccessible.cpp
+@@ -2532,6 +2532,13 @@ bool QAccessibleSelectionInterface::isSelected(QAccessibleInterface *childItem)
+     return selectedItems().contains(childItem);
+ }
+ 
++/*!
++    Destroys the QAccessibleAttributesInterface.
++*/
++QAccessibleAttributesInterface::~QAccessibleAttributesInterface()
++{
++}
++
+ /*!
+     \class QAccessibleTableCellInterface
+     \inmodule QtGui
+diff --git a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
+index 403c45cefc0..23a14923d35 100644
+--- a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
++++ b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
+@@ -500,6 +502,20 @@ HRESULT QWindowsUiaMainProvider::GetPropertyValue(PROPERTYID idProp, VARIANT *pR
+     case UIA_FullDescriptionPropertyId:
+         setVariantString(accessible->text(QAccessible::Description), pRetVal);
+         break;
++    case UIA_OrientationPropertyId: {
++        long orientationType = OrientationType_None;
++        if (QAccessibleAttributesInterface *attributesInterface = accessible->attributesInterface()) {
++            const QVariant orientation =
++                    attributesInterface->attributeValue(QAccessible::Attribute::Orientation);
++            if (orientation.isValid()) {
++                orientationType = (orientation.toInt() == Qt::Horizontal)
++                        ? OrientationType_Horizontal
++                        : OrientationType_Vertical;
++            }
++        }
++        setVariantI4(orientationType, pRetVal);
++        break;
++    }
+     case UIA_NamePropertyId: {
+         QString name = accessible->text(QAccessible::Name);
+         if (name.isEmpty() && topLevelWindow)


### PR DESCRIPTION
Backports two Qt 6 accessibility interfaces to the Qt 5.15.19 Windows UIA bridge so custom tab controls (e.g. the chat-folders strip) expose **selection** and **orientation** the same way Qt 6 does.

- `0037` — **`QAccessibleSelectionInterface`**: the bridge routes the Selection / SelectionItem patterns through the container's selection interface (as Qt 6 does), so the current tab is reported from `state().selected`, decoupled from keyboard focus.
- `0038` — **`QAccessibleAttributesInterface`**: the bridge answers `UIA_OrientationPropertyId` from the `Orientation` attribute, so a vertical/horizontal tab list is announced as such.

No `PageTab` role logic is added to the bridge — both patches just consult the interfaces. The interfaces are implemented on the container in desktop-app/lib_ui#304.

**Cross-platform:** on Qt 6 this is native (no patch needed). On Qt 5.15 macOS/Linux the interfaces exist but those bridges don't consult them yet, so they're simply inert there — lib_ui#304's behaviour isn't broken, just not exposed (same as any other 5.15 accessibility gap). Behaviour is either native (Qt 6) or inert (5.15 non-Windows); nothing diverges silently between platforms.

Based on current `master`; `0037` stacks on the merged `0035-fix-uia-selection-container-no-action-interface`, and `0038` on `0037`. Verified on a Qt 5.15.19 Windows build with NVDA.
