### PR TITLE
Upload dirty region rects instead of bounding rect in RHI backing store.

### DIFF
--- a/qtbase_6.11.1/0039-fix-backing-store-rhi-upload-dirty-rects.patch
+++ b/qtbase_6.11.1/0039-fix-backing-store-rhi-upload-dirty-rects.patch
@@ -1,0 +1,37 @@
+diff --git a/src/gui/painting/qbackingstoredefaultcompositor.cpp b/src/gui/painting/qbackingstoredefaultcompositor.cpp
+index 3130a8aea98..5d1d97f506a 100644
+--- a/src/gui/painting/qbackingstoredefaultcompositor.cpp
++++ b/src/gui/painting/qbackingstoredefaultcompositor.cpp
+@@ -110,13 +110,25 @@ QRhiTexture *QBackingStoreDefaultCompositor::toTexture(const QImage &sourceImage
+         m_texture->create();
+         resourceUpdates->uploadTexture(m_texture.get(), image);
+     } else {
+-        QRect imageRect = image.rect();
+-        QRect rect = dirtyRegion.boundingRect() & imageRect;
+-        QRhiTextureSubresourceUploadDescription subresDesc(image);
+-        subresDesc.setSourceTopLeft(rect.topLeft());
+-        subresDesc.setSourceSize(rect.size());
+-        subresDesc.setDestinationTopLeft(rect.topLeft());
+-        QRhiTextureUploadDescription uploadDesc(QRhiTextureUploadEntry(0, 0, subresDesc));
++        const QRect imageRect = image.rect();
++        // Uploading dirtyRegion.boundingRect() re-uploads the whole window when
++        // the dirty region consists of a few far-apart rects (e.g. a hovered
++        // item plus an unrelated update elsewhere). Upload each rect on its own
++        // instead: this never uploads more than the bounding rect would have and
++        // avoids a full-window glTexSubImage2D for sparse damage.
++        QVarLengthArray<QRhiTextureUploadEntry, 8> entries;
++        for (const QRect &dirtyRect : dirtyRegion) {
++            const QRect rect = dirtyRect & imageRect;
++            if (rect.isEmpty())
++                continue;
++            QRhiTextureSubresourceUploadDescription subresDesc(image);
++            subresDesc.setSourceTopLeft(rect.topLeft());
++            subresDesc.setSourceSize(rect.size());
++            subresDesc.setDestinationTopLeft(rect.topLeft());
++            entries.append(QRhiTextureUploadEntry(0, 0, subresDesc));
++        }
++        QRhiTextureUploadDescription uploadDesc;
++        uploadDesc.setEntries(entries.cbegin(), entries.cend());
+         resourceUpdates->uploadTexture(m_texture.get(), uploadDesc);
+     }
+ 


### PR DESCRIPTION
QBackingStoreDefaultCompositor::toTexture() uploaded dirtyRegion.boundingRect(), so a dirty region made of a few small, far-apart rects (e.g. a hovered list row plus an unrelated update elsewhere) re-uploads the whole bounding box including all the untouched pixels in between. Upload each rect of the region separately instead: QRhi supports multiple upload entries per subresource, the uploaded data never exceeds the bounding rect, and this matches what QOpenGLCompositorBackingStore already does.