### PR TITLE
Backport accessible automation id from QAccessible::UserText

### DIFF
--- a/qtbase_5.15.19/0037-accessible-automation-id-from-usertext.patch
+++ b/qtbase_5.15.19/0037-accessible-automation-id-from-usertext.patch
@@ -1,0 +1,14 @@
+diff --git a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
+index 403c45cefc0..91e9589de42 100644
+--- a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
++++ b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
+@@ -518,6 +518,9 @@ QString QWindowsUiaMainProvider::automationIdForAccessible(const QAccessibleInterface *accessible)
+ {
+     QString result;
+     if (accessible) {
++        const QString userText = accessible->text(QAccessible::UserText);
++        if (!userText.isEmpty())
++            return userText;
+         QObject *obj = accessible->object();
+         while (obj) {
+             QString name = obj->objectName();


### PR DESCRIPTION
Adds `qtbase_5.15.19/0037-accessible-automation-id-from-usertext.patch`.

`QWindowsUiaMainProvider::automationIdForAccessible()` is made to first read a hand-set `QAccessible::UserText` value and, when non-empty, return it directly - before walking the parent objectName chain. This backports the Qt 6.8+ `QAccessible::Identifier` behaviour to Qt 5.15, letting widgets expose a stable, language-independent UI Automation id (useful for screen-reader add-ons that navigate by id).

Self-contained: one new patch file, no dependency on other open patches PRs.