### PR TITLE
Raise UIA events for selected state changes

### DIFF
--- a/qtbase_5.15.19/0039-notify-selected-state-changes.patch
+++ b/qtbase_5.15.19/0039-notify-selected-state-changes.patch
@@ -1,0 +1,27 @@
+diff --git a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
+index dcd548bab28..fce78c5aa70 100644
+--- a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
++++ b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
+@@ -139,6 +139,22 @@ void QWindowsUiaMainProvider::notifyStateChange(QAccessibleStateChangeEvent *eve
+                 }
+             }
+         }
++        if (event->changedStates().selected) {
++            // Notifies selection changes on selectable items, so that
++            // screen readers can announce "selected"/"not selected" for
++            // the focused item in multi-selection lists (the same events
++            // the File Explorer items view raises).
++            if (accessible->state().selectable) {
++                if (QWindowsUiaMainProvider *provider = providerForAccessible(accessible)) {
++                    if (accessible->state().selected) {
++                        QWindowsUiaWrapper::instance()->raiseAutomationEvent(provider, UIA_SelectionItem_ElementAddedToSelectionEventId);
++                    } else {
++                        QWindowsUiaWrapper::instance()->raiseAutomationEvent(provider, UIA_SelectionItem_ElementRemovedFromSelectionEventId);
++                    }
++                    provider->Release();
++                }
++            }
++        }
+         if (event->changedStates().active) {
+             if (accessible->role() == QAccessible::Window) {
+                 // Notifies window opened/closed.


### PR DESCRIPTION
﻿Qt's Windows UIA bridge drops `selected` state changes entirely: `QWindowsUiaMainProvider::notifyStateChange` only forwards `checked`/`checkStateMixed` and `active`, so a `QAccessibleStateChangeEvent` with `selected` never reaches screen readers. The gap is still present in Qt dev, so there is nothing to backport.

This matters for multi-selection lists (Telegram message history keyboard selection, tdesktop#30947): the item stays focused while its selected state flips, and NVDA can only announce "selected"/"not selected" from an event. The single-select `ElementSelectedEventId` path (`notifySelectionChange`) has the wrong semantics for toggling one item of many.

The patch makes `notifyStateChange` raise `UIA_SelectionItem_ElementAddedToSelectionEventId` / `ElementRemovedFromSelectionEventId` for selectable items - the same events the File Explorer items view raises, which NVDA announces as "selected"/"not selected" for the focused item.
