### PR TITLE
fix paced widget update delivery on macos

### DIFF
--- a/qtbase_6.11.1/0041-macos-widget-updates-via-display-link.patch
+++ b/qtbase_6.11.1/0041-macos-widget-updates-via-display-link.patch
@@ -1,3 +1,118 @@
+diff --git a/src/plugins/platforms/cocoa/qcocoascreen.h b/src/plugins/platforms/cocoa/qcocoascreen.h
+index 3cefde3812d..3e0618396b1 100644
+--- a/src/plugins/platforms/cocoa/qcocoascreen.h
++++ b/src/plugins/platforms/cocoa/qcocoascreen.h
+@@ -97,7 +97,7 @@ private:
+     qreal m_rotation = 0;
+ 
+     CVDisplayLinkRef m_displayLink = nullptr;
+-    dispatch_source_t m_displayLinkSource = nullptr;
++    CFRunLoopSourceRef m_updateRunLoopSource = nullptr;
+     QAtomicInt m_pendingUpdateRequests;
+     QAtomicInt m_pendingDisplayLinkUpdates;
+ 
+diff --git a/src/plugins/platforms/cocoa/qcocoascreen.mm b/src/plugins/platforms/cocoa/qcocoascreen.mm
+index d612964e24b..88e5ae7439b 100644
+--- a/src/plugins/platforms/cocoa/qcocoascreen.mm
++++ b/src/plugins/platforms/cocoa/qcocoascreen.mm
+@@ -198,8 +198,10 @@ QCocoaScreen::~QCocoaScreen()
+     delete m_cursor;
+ 
+     CVDisplayLinkRelease(m_displayLink);
+-    if (m_displayLinkSource)
+-         dispatch_release(m_displayLinkSource);
++    if (m_updateRunLoopSource) {
++        CFRunLoopSourceInvalidate(m_updateRunLoopSource);
++        CFRelease(m_updateRunLoopSource);
++    }
+ }
+ 
+ void QCocoaScreen::update(CGDirectDisplayID displayId)
+@@ -419,21 +421,29 @@ void QCocoaScreen::deliverUpdateRequests()
+             return;
+         }
+ 
+-        qDeferredDebug(screenUpdates) << "; signaling dispatch source";
+-
+-        if (!m_displayLinkSource) {
+-            m_displayLinkSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_DATA_ADD, 0, 0, dispatch_get_main_queue());
+-            dispatch_source_set_event_handler(m_displayLinkSource, ^{
+-                deliverUpdateRequests();
+-            });
+-            dispatch_resume(m_displayLinkSource);
++        // Patched: marshal via a version-0 CFRunLoopSource instead of a GCD
++        // source on the main dispatch queue. The dispatch queue is only
++        // drained when the main runloop goes to sleep, so a busy event loop
++        // (continuous timers/posted events) starves it for many frames;
++        // runloop sources are serviced on every iteration.
++        qDeferredDebug(screenUpdates) << "; signaling runloop source";
++        if (!m_updateRunLoopSource) {
++            CFRunLoopSourceContext context = {};
++            context.info = this;
++            context.perform = [](void *info) {
++                static_cast<QCocoaScreen *>(info)->deliverUpdateRequests();
++            };
++            m_updateRunLoopSource = CFRunLoopSourceCreate(
++                kCFAllocatorDefault, 0, &context);
++            CFRunLoopAddSource(CFRunLoopGetMain(),
++                m_updateRunLoopSource, kCFRunLoopCommonModes);
+         }
+-
+-        dispatch_source_merge_data(m_displayLinkSource, 1);
++        CFRunLoopSourceSignal(m_updateRunLoopSource);
++        CFRunLoopWakeUp(CFRunLoopGetMain());
+ 
+     } else {
+         DeferredDebugHelper screenUpdates(lcQpaScreenUpdates());
+-        qDeferredDebug(screenUpdates) << "gcd event handler on main thread";
++        qDeferredDebug(screenUpdates) << "runloop source callout on main thread";
+ 
+         const int pendingUpdates = m_pendingDisplayLinkUpdates;
+         if (pendingUpdates > 1)
+@@ -441,8 +451,6 @@ void QCocoaScreen::deliverUpdateRequests()
+ 
+         screenUpdates.flushOutput();
+ 
+-        int pendingUpdateRequests = 0;
+-
+         auto windows = QGuiApplication::allWindows();
+         for (int i = 0; i < windows.size(); ++i) {
+             QWindow *window = windows.at(i);
+@@ -461,16 +469,28 @@ void QCocoaScreen::deliverUpdateRequests()
+                 continue;
+ 
+             platformWindow->deliverUpdateRequest();
++        }
+ 
+-            // platform window can be destroyed in deliverUpdateRequest()
++        // Patched: recount pending update requests in a separate pass after
++        // all deliveries. Counting each window right after its delivery lost
++        // requests made by an already-counted window during a later window's
++        // delivery: the store below clobbered their increments, leaving the
++        // window's updateRequestPending flag set (so its own requestUpdate()
++        // no-ops) while the display link sees zero pending requests and never
++        // signals delivery again -- a permanent paint freeze until some other
++        // window requests an update. This pass is straight-line reads, so no
++        // request can interleave between the count and the store.
++        int pendingUpdateRequests = 0;
++        for (QWindow *window : QGuiApplication::allWindows()) {
++            if (window->screen() != screen())
++                continue;
++            auto *platformWindow = static_cast<QCocoaWindow*>(window->handle());
+             if (!platformWindow)
+                 continue;
+-
+-            // The update request delivery could result in another request
+-            // from the window, or the platform window could decide to not
+-            // deliver the request at this time.
+-            if (platformWindow->hasPendingUpdateRequest())
++            if (platformWindow->hasPendingUpdateRequest()
++                    && platformWindow->updatesWithDisplayLink()) {
+                 ++pendingUpdateRequests;
++            }
+         }
+ 
+         m_pendingUpdateRequests = pendingUpdateRequests;
 diff --git a/src/widgets/kernel/qwidgetrepaintmanager.cpp b/src/widgets/kernel/qwidgetrepaintmanager.cpp
 index 90df68d4f9b..5c58722866e 100644
 --- a/src/widgets/kernel/qwidgetrepaintmanager.cpp


### PR DESCRIPTION
followup to 0041: routing all widget repaints through the display link exposed two issues in QCocoaScreen.

the gcd source that marshals the display link callback to the main thread is only drained when the runloop goes to sleep, so a busy event loop delays paint delivery by several frames (visible as scroll/video hitches). a version-0 runloop source is serviced on every runloop iteration instead.

also, an update request made by an already-counted window during a later window's delivery was clobbered by the pending-request recount in deliverUpdateRequests. that leaves the window's updateRequestPending flag set while the screen counter reads zero, so the display link never signals delivery again and the window's own requestUpdate() no-ops — paints freeze for that window (multi-second video freezes) until some other window requests an update. the recount now runs in a separate pass after all deliveries.

both issues were root-caused by claude fable 5.