### PR TITLE
qtbase: pass fractional wheel pixel deltas through to QWheelEvent

### DIFF
--- a/qtbase_6.11.1/0042-pass-fractional-pixel-deltas-in-wheel-events.patch
+++ b/qtbase_6.11.1/0042-pass-fractional-pixel-deltas-in-wheel-events.patch
@@ -1,0 +1,236 @@
+diff --git a/src/gui/kernel/qevent.cpp b/src/gui/kernel/qevent.cpp
+index 0b1e3414ded..54c8be4d3d2 100644
+--- a/src/gui/kernel/qevent.cpp
++++ b/src/gui/kernel/qevent.cpp
+@@ -1223,9 +1223,11 @@ Q_IMPL_POINTER_EVENT(QHoverEvent)
+ */
+ QWheelEvent::QWheelEvent(const QPointF &pos, const QPointF &globalPos, QPoint pixelDelta, QPoint angleDelta,
+                          Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers, Qt::ScrollPhase phase,
+-                         bool inverted, Qt::MouseEventSource source, const QPointingDevice *device)
++                         bool inverted, Qt::MouseEventSource source, const QPointingDevice *device,
++                         QPointF pixelDeltaF)
+     : QSinglePointEvent(Wheel, device, pos, pos, globalPos, Qt::NoButton, buttons, modifiers, source),
+-      m_pixelDelta(pixelDelta), m_angleDelta(angleDelta)
++      m_pixelDelta(pixelDelta), m_angleDelta(angleDelta),
++      m_pixelDeltaF(pixelDeltaF.isNull() ? QPointF(pixelDelta) : pixelDeltaF)
+ {
+     m_phase = phase;
+     m_invertedScrolling = inverted;
+diff --git a/src/gui/kernel/qevent.h b/src/gui/kernel/qevent.h
+index 2aa7de1e245..932347c0a12 100644
+--- a/src/gui/kernel/qevent.h
++++ b/src/gui/kernel/qevent.h
+@@ -294,9 +294,11 @@ public:
+     QWheelEvent(const QPointF &pos, const QPointF &globalPos, QPoint pixelDelta, QPoint angleDelta,
+                 Qt::MouseButtons buttons, Qt::KeyboardModifiers modifiers, Qt::ScrollPhase phase,
+                 bool inverted, Qt::MouseEventSource source = Qt::MouseEventNotSynthesized,
+-                const QPointingDevice *device = QPointingDevice::primaryPointingDevice());
++                const QPointingDevice *device = QPointingDevice::primaryPointingDevice(),
++                QPointF pixelDeltaF = QPointF());
+ 
+     inline QPoint pixelDelta() const { return m_pixelDelta; }
++    inline QPointF pixelDeltaF() const { return m_pixelDeltaF; }
+     inline QPoint angleDelta() const { return m_angleDelta; }
+ 
+     inline Qt::ScrollPhase phase() const { return Qt::ScrollPhase(m_phase); }
+@@ -312,6 +314,7 @@ public:
+ protected:
+     QPoint m_pixelDelta;
+     QPoint m_angleDelta;
++    QPointF m_pixelDeltaF;
+ };
+ #endif
+ 
+diff --git a/src/gui/kernel/qwindowsysteminterface.cpp b/src/gui/kernel/qwindowsysteminterface.cpp
+index 15cea9663e7..cdd20faace0 100644
+--- a/src/gui/kernel/qwindowsysteminterface.cpp
++++ b/src/gui/kernel/qwindowsysteminterface.cpp
+@@ -499,23 +499,23 @@ bool QWindowSystemInterface::handleExtendedKeyEvent(QWindow *window, ulong times
+         timestamp, type, key, modifiers, nativeScanCode, nativeVirtualKey, nativeModifiers, text, autorep, count);
+ }
+ 
+-bool QWindowSystemInterface::handleWheelEvent(QWindow *window, const QPointF &local, const QPointF &global, QPoint pixelDelta, QPoint angleDelta, Qt::KeyboardModifiers mods, Qt::ScrollPhase phase, Qt::MouseEventSource source)
++bool QWindowSystemInterface::handleWheelEvent(QWindow *window, const QPointF &local, const QPointF &global, QPoint pixelDelta, QPoint angleDelta, Qt::KeyboardModifiers mods, Qt::ScrollPhase phase, Qt::MouseEventSource source, QPointF pixelDeltaF)
+ {
+     unsigned long time = QWindowSystemInterfacePrivate::eventTime.elapsed();
+-    return handleWheelEvent(window, time, local, global, pixelDelta, angleDelta, mods, phase, source);
++    return handleWheelEvent(window, time, local, global, pixelDelta, angleDelta, mods, phase, source, false, pixelDeltaF);
+ }
+ 
+ bool QWindowSystemInterface::handleWheelEvent(QWindow *window, ulong timestamp, const QPointF &local, const QPointF &global, QPoint pixelDelta, QPoint angleDelta, Qt::KeyboardModifiers mods, Qt::ScrollPhase phase,
+-                                              Qt::MouseEventSource source, bool invertedScrolling)
++                                              Qt::MouseEventSource source, bool invertedScrolling, QPointF pixelDeltaF)
+ {
+     return handleWheelEvent(window, timestamp, QPointingDevice::primaryPointingDevice(), local, global,
+-                            pixelDelta, angleDelta, mods, phase, source, invertedScrolling);
++                            pixelDelta, angleDelta, mods, phase, source, invertedScrolling, pixelDeltaF);
+ }
+ 
+ bool QWindowSystemInterface::handleWheelEvent(QWindow *window, ulong timestamp, const QPointingDevice *device,
+                                               const QPointF &local, const QPointF &global, QPoint pixelDelta, QPoint angleDelta,
+                                               Qt::KeyboardModifiers mods, Qt::ScrollPhase phase,
+-                                              Qt::MouseEventSource source, bool invertedScrolling)
++                                              Qt::MouseEventSource source, bool invertedScrolling, QPointF pixelDeltaF)
+ {
+     // Qt 4 sends two separate wheel events for horizontal and vertical
+     // deltas. For Qt 5 we want to send the deltas in one event, but at the
+@@ -534,14 +534,14 @@ bool QWindowSystemInterface::handleWheelEvent(QWindow *window, ulong timestamp,
+     if (angleDelta.y() != 0 && angleDelta.x() == 0) {
+         return handleWindowSystemEvent<QWindowSystemInterfacePrivate::WheelEvent>(window,
+             timestamp, QHighDpi::fromNativeLocalPosition(local, window), QHighDpi::fromNativeGlobalPosition(global, window),
+-            pixelDelta, angleDelta, angleDelta.y(), Qt::Vertical, mods, phase, source, invertedScrolling, device);
++            pixelDelta, angleDelta, angleDelta.y(), Qt::Vertical, mods, phase, source, invertedScrolling, device, pixelDeltaF);
+     }
+ 
+     // Simple case: horizontal deltas only:
+     if (angleDelta.y() == 0 && angleDelta.x() != 0) {
+         return handleWindowSystemEvent<QWindowSystemInterfacePrivate::WheelEvent>(window,
+             timestamp, QHighDpi::fromNativeLocalPosition(local, window), QHighDpi::fromNativeGlobalPosition(global, window),
+-            pixelDelta, angleDelta, angleDelta.x(), Qt::Horizontal, mods, phase, source, invertedScrolling, device);
++            pixelDelta, angleDelta, angleDelta.x(), Qt::Horizontal, mods, phase, source, invertedScrolling, device, pixelDeltaF);
+     }
+ 
+     bool acceptVert;
+@@ -551,7 +551,7 @@ bool QWindowSystemInterface::handleWheelEvent(QWindow *window, ulong timestamp,
+     // and in addition the Qt 4 compatibility vertical angle delta.
+     acceptVert = handleWindowSystemEvent<QWindowSystemInterfacePrivate::WheelEvent>(window,
+         timestamp, QHighDpi::fromNativeLocalPosition(local, window), QHighDpi::fromNativeGlobalPosition(global, window),
+-        pixelDelta, angleDelta, angleDelta.y(), Qt::Vertical, mods, phase, source, invertedScrolling, device);
++        pixelDelta, angleDelta, angleDelta.y(), Qt::Vertical, mods, phase, source, invertedScrolling, device, pixelDeltaF);
+ 
+     // The second event contains null pixel and angle points and the
+     // Qt 4 compatibility horizontal angle delta.
+diff --git a/src/gui/kernel/qwindowsysteminterface.h b/src/gui/kernel/qwindowsysteminterface.h
+index d6783fca47f..8efb6b1f288 100644
+--- a/src/gui/kernel/qwindowsysteminterface.h
++++ b/src/gui/kernel/qwindowsysteminterface.h
+@@ -91,20 +91,23 @@ public:
+                                  QPoint pixelDelta, QPoint angleDelta,
+                                  Qt::KeyboardModifiers mods = Qt::NoModifier,
+                                  Qt::ScrollPhase phase = Qt::NoScrollPhase,
+-                                 Qt::MouseEventSource source = Qt::MouseEventNotSynthesized);
++                                 Qt::MouseEventSource source = Qt::MouseEventNotSynthesized,
++                                 QPointF pixelDeltaF = QPointF());
+     static bool handleWheelEvent(QWindow *window, ulong timestamp, const QPointF &local, const QPointF &global,
+                                  QPoint pixelDelta, QPoint angleDelta,
+                                  Qt::KeyboardModifiers mods = Qt::NoModifier,
+                                  Qt::ScrollPhase phase = Qt::NoScrollPhase,
+                                  Qt::MouseEventSource source = Qt::MouseEventNotSynthesized,
+-                                 bool inverted = false);
++                                 bool inverted = false,
++                                 QPointF pixelDeltaF = QPointF());
+     static bool handleWheelEvent(QWindow *window, ulong timestamp, const QPointingDevice *device,
+                                  const QPointF &local, const QPointF &global,
+                                  QPoint pixelDelta, QPoint angleDelta,
+                                  Qt::KeyboardModifiers mods = Qt::NoModifier,
+                                  Qt::ScrollPhase phase = Qt::NoScrollPhase,
+                                  Qt::MouseEventSource source = Qt::MouseEventNotSynthesized,
+-                                 bool inverted = false);
++                                 bool inverted = false,
++                                 QPointF pixelDeltaF = QPointF());
+ 
+     // A very-temporary QPA touchpoint which gets converted to a QEventPoint as early as possible
+     // in QWindowSystemInterfacePrivate::fromNativeTouchPoints()
+diff --git a/src/gui/kernel/qwindowsysteminterface_p.h b/src/gui/kernel/qwindowsysteminterface_p.h
+index 907dc4a5513..bd40fc35e44 100644
+--- a/src/gui/kernel/qwindowsysteminterface_p.h
++++ b/src/gui/kernel/qwindowsysteminterface_p.h
+@@ -244,9 +244,11 @@ public:
+     public:
+         WheelEvent(QWindow *w, ulong time, const QPointF &local, const QPointF &global, QPoint pixelD, QPoint angleD, int qt4D, Qt::Orientation qt4O,
+                    Qt::KeyboardModifiers mods, Qt::ScrollPhase phase = Qt::NoScrollPhase, Qt::MouseEventSource src = Qt::MouseEventNotSynthesized,
+-                   bool inverted = false, const QPointingDevice *device = QPointingDevice::primaryPointingDevice())
++                   bool inverted = false, const QPointingDevice *device = QPointingDevice::primaryPointingDevice(),
++                   QPointF pixelDF = QPointF())
+             : PointerEvent(w, time, Wheel, mods, device), pixelDelta(pixelD), angleDelta(angleD), qt4Delta(qt4D),
+-              qt4Orientation(qt4O), localPos(local), globalPos(global), phase(phase), source(src), inverted(inverted) { }
++              qt4Orientation(qt4O), localPos(local), globalPos(global), phase(phase), source(src), inverted(inverted),
++              pixelDeltaF(pixelDF) { }
+         QPoint pixelDelta;
+         QPoint angleDelta;
+         int qt4Delta;
+@@ -256,6 +258,7 @@ public:
+         Qt::ScrollPhase phase;
+         Qt::MouseEventSource source;
+         bool inverted;
++        QPointF pixelDeltaF;
+     };
+ 
+     class KeyEvent : public InputEvent {
+diff --git a/src/gui/kernel/qguiapplication.cpp b/src/gui/kernel/qguiapplication.cpp
+--- a/src/gui/kernel/qguiapplication.cpp
++++ b/src/gui/kernel/qguiapplication.cpp
+@@ -2574,7 +2574,8 @@
+ 
+     const QPointingDevice *device = static_cast<const QPointingDevice *>(e->device);
+     QWheelEvent ev(localPoint, globalPoint, e->pixelDelta, e->angleDelta,
+-                   mouse_buttons, e->modifiers, e->phase, e->inverted, e->source, device);
++                   mouse_buttons, e->modifiers, e->phase, e->inverted, e->source, device,
++                   e->pixelDeltaF);
+     ev.setTimestamp(e->timestamp);
+     QGuiApplication::sendSpontaneousEvent(window, &ev);
+     e->eventAccepted = ev.isAccepted();
+diff --git a/src/widgets/kernel/qwidgetwindow.cpp b/src/widgets/kernel/qwidgetwindow.cpp
+--- a/src/widgets/kernel/qwidgetwindow.cpp
++++ b/src/widgets/kernel/qwidgetwindow.cpp
+@@ -954,7 +954,7 @@
+ 
+     QWheelEvent translated(mapped, event->globalPosition(), event->pixelDelta(), event->angleDelta(),
+                            event->buttons(), event->modifiers(), event->phase(), event->inverted(),
+-                           event->source(), event->pointingDevice());
++                           event->source(), event->pointingDevice(), event->pixelDeltaF());
+     translated.setTimestamp(event->timestamp());
+     QGuiApplication::forwardEvent(widget, &translated, event);
+ }
+diff --git a/src/widgets/kernel/qapplication.cpp b/src/widgets/kernel/qapplication.cpp
+--- a/src/widgets/kernel/qapplication.cpp
++++ b/src/widgets/kernel/qapplication.cpp
+@@ -2861,7 +2861,8 @@
+             }
+ 
+             QWheelEvent we(relpos, wheel->globalPosition(), wheel->pixelDelta(), wheel->angleDelta(), wheel->buttons(),
+-                            wheel->modifiers(), phase, wheel->inverted(), wheel->source(), wheel->pointingDevice());
++                            wheel->modifiers(), phase, wheel->inverted(), wheel->source(), wheel->pointingDevice(),
++                            wheel->pixelDeltaF());
+ 
+             we.setTimestamp(wheel->timestamp());
+             bool eventAccepted;
+diff --git a/src/plugins/platforms/cocoa/qnsview_mouse.mm b/src/plugins/platforms/cocoa/qnsview_mouse.mm
+--- a/src/plugins/platforms/cocoa/qnsview_mouse.mm
++++ b/src/plugins/platforms/cocoa/qnsview_mouse.mm
+@@ -695,15 +695,18 @@
+     }
+ 
+     QPoint pixelDelta;
++    QPointF pixelDeltaF;
+     if ([theEvent hasPreciseScrollingDeltas]) {
+         pixelDelta.setX([theEvent scrollingDeltaX]);
+         pixelDelta.setY([theEvent scrollingDeltaY]);
++        pixelDeltaF = QPointF([theEvent scrollingDeltaX], [theEvent scrollingDeltaY]);
+     } else {
+         // docs: "In the case of !hasPreciseScrollingDeltas, multiply the delta with the line width."
+         // scrollingDeltaX seems to return a minimum value of 0.1 in this case, map that to two pixels.
+         const CGFloat lineWithEstimate = 20.0;
+         pixelDelta.setX([theEvent scrollingDeltaX] * lineWithEstimate);
+         pixelDelta.setY([theEvent scrollingDeltaY] * lineWithEstimate);
++        pixelDeltaF = QPointF(pixelDelta);
+     }
+ 
+     QPointF qt_windowPoint;
+@@ -757,6 +760,7 @@
+         if (!pixelDelta.isNull() || !angleDelta.isNull()) {
+             qCInfo(lcQpaMouse) << "Ignoring unexpected delta for" << theEvent;
+             pixelDelta = QPoint();
++            pixelDeltaF = QPointF();
+             angleDelta = QPoint();
+         }
+     }
+@@ -793,7 +797,7 @@
+ 
+     QWindowSystemInterface::handleWheelEvent(m_platformWindow->window(), qt_timestamp,
+         device, qt_windowPoint, qt_screenPoint, pixelDelta, angleDelta,
+-        m_currentWheelModifiers, phase, source, isInverted);
++        m_currentWheelModifiers, phase, source, isInverted, pixelDeltaF);
+ }
+ #endif // QT_CONFIG(wheelevent)
+ 


### PR DESCRIPTION
qt receives fractional scroll deltas from the OS (NSEvent's `scrollingDelta` on macos) but rounds them to whole logical pixels when filling `QWheelEvent::pixelDelta()`, which makes slow trackpad scrolling stuttery — at ~1px/frame the integer stream goes 0-0-1-0-1 while the finger moves smoothly.

this patch (`qtbase_6.11.1/0042`) is strictly additive: `pixelDelta()` and all existing behavior are byte-for-byte unchanged. it adds a `QPointF pixelDeltaF()` getter on `QWheelEvent` carrying the exact fractional delta, plumbed as a defaulted trailing parameter through the cocoa QPA → `QWindowSystemInterface::handleWheelEvent` → `QWindowSystemInterfacePrivate::WheelEvent` → `QGuiApplicationPrivate::processWheelEvent`, and forwarded in the two places qtwidgets reconstructs wheel events (`qwidgetwindow.cpp`, `qapplication.cpp`). when constructed without the extra argument, `pixelDeltaF()` falls back to the rounded `pixelDelta`, so unaware code paths keep working.

we first tried changing `pixelDelta()` itself to return `QPointF`, but that caused random breakages throughout the codebase: every `auto` deduction silently shifted to `qreal`, breaking template deduction where types mix (`std::clamp` with int bounds) and silently changing semantics elsewhere (`pixel.y() ? ...` — a 0.4 delta was falsy before, truthy after; truncation instead of qt's rounding). the additive getter avoids all of that.

consumed by desktop-app/lib_ui#324 (via `if constexpr (requires { e->pixelDeltaF(); })`, so lib_ui still compiles against stock qt) for sub-pixel smooth scrolling in telegramdesktop/tdesktop#31023.

note: this patch was written by claude fable 5.
