### PR TITLE
Backport raising the UIA focus event for the focused child

### DIFF
--- a/qtbase_5.15.19/0040-backport-uia-focus-child-for-any-element.patch
+++ b/qtbase_5.15.19/0040-backport-uia-focus-child-for-any-element.patch
@@ -1,0 +1,17 @@
+diff --git a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
+--- a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
++++ b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
+@@ -110,10 +110,11 @@
+ void QWindowsUiaMainProvider::notifyFocusChange(QAccessibleEvent *event)
+ {
+     if (QAccessibleInterface *accessible = event->accessibleInterface()) {
+-        // If this is a table/tree/list, raise event for the focused cell/item instead.
+-        if (accessible->tableInterface())
++        // If this is a complex element, raise event for the focused child instead.
++        if (accessible->childCount()) {
+             if (QAccessibleInterface *child = accessible->focusChild())
+                 accessible = child;
++        }
+         if (QWindowsUiaMainProvider *provider = providerForAccessible(accessible)) {
+             QWindowsUiaWrapper::instance()->raiseAutomationEvent(provider, UIA_AutomationFocusChangedEventId);
+             provider->Release();


### PR DESCRIPTION
Qt 5.15 forwards a focus event to focusChild() only for an accessible with a table interface:

    // If this is a table/tree/list, raise event for the focused cell/item instead.
    if (accessible->tableInterface())

Upstream generalized that to any element with children - the same code in 6.2 and in dev reads:

    // If this is a complex element, raise event for the focused child instead.
    if (accessible->childCount()) {

Without it a container of painted (virtual) children can't hand the focus over: the container is the only element in the window reporting the keyboard focus, so a screen reader announces the container instead of the item that focusChild() points at. The lists in Telegram that are painted rather than built of widgets - the chat list, the message list, the countries and languages lists, the chat folder tabs - all work around it by raising a focus event for the child themselves, which then makes a screen reader announce both the container and the item. With this patch the workaround can go away and the behaviour matches Qt 6.