### PR TITLE
Backport raising the UIA name change for the focused element

### DIFF
--- a/qtbase_5.15.19/0040-backport-uia-focus-child-for-any-element.patch
+++ b/qtbase_5.15.19/0040-backport-uia-focus-child-for-any-element.patch
@@ -1,0 +1,17 @@
+diff --git a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
+--- a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
++++ b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
+@@ -110,10 +110,11 @@
+ void QWindowsUiaMainProvider::notifyFocusChange(QAccessibleEvent *event)
+ {
+     if (QAccessibleInterface *accessible = event->accessibleInterface()) {
+-        // If this is a table/tree/list, raise event for the focused cell/item instead.
+-        if (accessible->tableInterface())
++        // If this is a complex element, raise event for the focused child instead.
++        if (accessible->childCount()) {
+             if (QAccessibleInterface *child = accessible->focusChild())
+                 accessible = child;
++        }
+         if (QWindowsUiaMainProvider *provider = providerForAccessible(accessible)) {
+             QWindowsUiaWrapper::instance()->raiseAutomationEvent(provider, UIA_AutomationFocusChangedEventId);
+             provider->Release();

--- a/qtbase_5.15.19/0041-backport-uia-name-change-for-focused-element.patch
+++ b/qtbase_5.15.19/0041-backport-uia-name-change-for-focused-element.patch
@@ -1,0 +1,16 @@
+diff --git a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
+--- a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
++++ b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
+@@ -203,9 +204,9 @@ void QWindowsUiaMainProvider::notifyValueChange(QAccessibleValueChangeEvent *eve
+ void QWindowsUiaMainProvider::notifyNameChange(QAccessibleEvent *event)
+ {
+     if (QAccessibleInterface *accessible = event->accessibleInterface()) {
+-        // Restrict notification to combo boxes, which need it for accessibility,
+-        // in order to avoid slowdowns with unnecessary notifications.
+-        if (accessible->role() == QAccessible::ComboBox) {
++        // Restrict notification to combo boxes and the currently focused element, which
++        // need it for accessibility, in order to avoid slowdowns with unnecessary notifications.
++        if (accessible->role() == QAccessible::ComboBox || accessible->state().focused) {
+             if (QWindowsUiaMainProvider *provider = providerForAccessible(accessible)) {
+                 VARIANT oldVal, newVal;
+                 clearVariant(&oldVal);


### PR DESCRIPTION
Stacked on #263: the first commit here is #263's patch (0040), this PR adds 0041 on top of it.

Qt 5.15 forwards a name change to UI Automation only for a combo box (qwindowsuiamainprovider.cpp, notifyNameChange), so a screen reader never hears one on the element it is sitting on. Upstream widened the condition to the focused element as well; it is in every current release - checked against v6.11.2 - and this backports that one line.

Painted lists are what need it: a row that renames itself under the user, or that folds a piece of its state into the name, says nothing on Windows without this, while the same code is heard on Linux (the AT-SPI adaptor forwards NameChanged unconditionally).
