### PR TITLE
Backport the PositionInSet/SizeOfSet accessibility attributes

### DIFF
--- a/qtbase_5.15.19/0042-backport-uia-set-attributes.patch
+++ b/qtbase_5.15.19/0042-backport-uia-set-attributes.patch
@@ -1,0 +1,74 @@
+diff --git a/src/gui/accessible/qaccessible.h b/src/gui/accessible/qaccessible.h
+index 121e519a338..f39ee239d90 100644
+--- a/src/gui/accessible/qaccessible.h
++++ b/src/gui/accessible/qaccessible.h
+@@ -390,6 +390,8 @@ public:
+         Level,
+         Locale,
+         Orientation,
++        PositionInSet,
++        SizeOfSet,
+     };
+     Q_ENUM(Attribute)
+ 
+diff --git a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
+index 1e399f99240..ca6c664b973 100644
+--- a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
++++ b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
+@@ -396,6 +396,24 @@ HRESULT QWindowsUiaMainProvider::GetPatternProvider(PATTERNID idPattern, IUnknow
+     return S_OK;
+ }
+ 
++void QWindowsUiaMainProvider::setIntAttribute(QAccessibleInterface *accessible,
++                                              QAccessible::Attribute attribute,
++                                              VARIANT *pRetVal)
++{
++    Q_ASSERT(accessible);
++
++    QAccessibleAttributesInterface *attributesIface = accessible->attributesInterface();
++    if (!attributesIface)
++        return;
++
++    const QVariant value = attributesIface->attributeValue(attribute);
++    if (!value.isValid())
++        return;
++
++    Q_ASSERT(value.canConvert<int>());
++    setVariantI4(value.toInt(), pRetVal);
++}
++
+ HRESULT QWindowsUiaMainProvider::GetPropertyValue(PROPERTYID idProp, VARIANT *pRetVal)
+ {
+     qCDebug(lcQpaUiAutomation) << __FUNCTION__ << idProp;
+@@ -517,6 +535,18 @@ HRESULT QWindowsUiaMainProvider::GetPropertyValue(PROPERTYID idProp, VARIANT *pR
+         setVariantI4(orientationType, pRetVal);
+         break;
+     }
++    case UIA_LevelPropertyId:
++        // Headings convey their level through the heading text style
++        // instead, the way upstream Qt maps them.
++        if (accessible->role() != QAccessible::Heading)
++            setIntAttribute(accessible, QAccessible::Attribute::Level, pRetVal);
++        break;
++    case UIA_PositionInSetPropertyId:
++        setIntAttribute(accessible, QAccessible::Attribute::PositionInSet, pRetVal);
++        break;
++    case UIA_SizeOfSetPropertyId:
++        setIntAttribute(accessible, QAccessible::Attribute::SizeOfSet, pRetVal);
++        break;
+     case UIA_NamePropertyId: {
+         QString name = accessible->text(QAccessible::Name);
+         if (name.isEmpty() && topLevelWindow)
+diff --git a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.h b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.h
+index 8aadabd227f..865f41082c2 100644
+--- a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.h
++++ b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.h
+@@ -98,6 +98,8 @@ public:
+ 
+ private:
+     QString automationIdForAccessible(const QAccessibleInterface *accessible);
++    static void setIntAttribute(QAccessibleInterface *accessible,
++                                QAccessible::Attribute attribute, VARIANT *pRetVal);
+     ULONG m_ref;
+     static QMutex m_mutex;
+ };

--- a/qtbase_6.11.2/0047-backport-uia-set-attributes.patch
+++ b/qtbase_6.11.2/0047-backport-uia-set-attributes.patch
@@ -1,0 +1,125 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+Date: Mon, 1 Sep 2026 12:00:00
+Subject: [PATCH] backported the PositionInSet/SizeOfSet accessibility attributes
+
+Backport of the Qt 6.13 change 64a9bd4c2291359a125b406bff43d3ecace07b42
+(QTBUG-149577): QAccessible::Attribute gains PositionInSet and SizeOfSet,
+so an accessible element can report its 1-based position within its set
+of siblings and the size of that set through
+QAccessibleAttributesInterface, and the Windows UIA bridge maps them to
+UIA_PositionInSetPropertyId / UIA_SizeOfSetPropertyId (and the existing
+Level attribute to UIA_LevelPropertyId for non-heading elements), so a
+screen reader announces "2 of 10" for a painted list item.
+
+diff --git a/src/gui/accessible/qaccessible.cpp b/src/gui/accessible/qaccessible.cpp
+index f735507651d..33ef394eeb7 100644
+--- a/src/gui/accessible/qaccessible.cpp
++++ b/src/gui/accessible/qaccessible.cpp
+@@ -461,6 +461,17 @@ Q_STATIC_LOGGING_CATEGORY(lcAccessibilityCore, "qt.accessibility.core");
+     \value [since 6.11] Orientation value type: \a Qt::Orientation
+                                 Orientation of the element. This attribute conceptually matches
+                                 the "aria-orientation" property in ARIA.
++    \value [since 6.13] PositionInSet value type: \a int
++                                1-based position of the element within the set of elements it
++                                belongs to, e.g. the position of an item in a list or of a radio
++                                button in its group. Together with \a SizeOfSet, this lets
++                                assistive technologies announce e.g. "item 2 of 10". This
++                                attribute conceptually matches the "aria-posinset" property
++                                in ARIA.
++    \value [since 6.13] SizeOfSet value type: \a int
++                                Number of elements in the set of elements the element belongs
++                                to. This attribute conceptually matches the "aria-setsize"
++                                property in ARIA.
+ 
+     \sa QAccessibleAttributesInterface
+ */
+diff --git a/src/gui/accessible/qaccessible_base.h b/src/gui/accessible/qaccessible_base.h
+index 04efeddf06f..4e12fea714b 100644
+--- a/src/gui/accessible/qaccessible_base.h
++++ b/src/gui/accessible/qaccessible_base.h
+@@ -383,6 +383,8 @@ public:
+         Level,
+         Locale,
+         Orientation,
++        PositionInSet,
++        SizeOfSet,
+     };
+     Q_ENUM(Attribute)
+ 
+diff --git a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
+index 6bd3c9395c9..95ace3b0496 100644
+--- a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
++++ b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.cpp
+@@ -460,6 +460,14 @@ void QWindowsUiaMainProvider::setAriaProperties(QAccessibleInterface *accessible
+             Q_ASSERT(value.canConvert<int>());
+             ariaString += QStringLiteral("level=") + QString::number(value.toInt());
+             break;
++        case QAccessible::Attribute::PositionInSet:
++            Q_ASSERT(value.canConvert<int>());
++            ariaString += QStringLiteral("posinset=") + QString::number(value.toInt());
++            break;
++        case QAccessible::Attribute::SizeOfSet:
++            Q_ASSERT(value.canConvert<int>());
++            ariaString += QStringLiteral("setsize=") + QString::number(value.toInt());
++            break;
+         default:
+             break;
+         }
+@@ -468,6 +476,24 @@ void QWindowsUiaMainProvider::setAriaProperties(QAccessibleInterface *accessible
+     *pRetVal = QComVariant{ ariaString }.release();
+ }
+ 
++void QWindowsUiaMainProvider::setIntAttribute(QAccessibleInterface *accessible,
++                                              QAccessible::Attribute attribute,
++                                              VARIANT *pRetVal)
++{
++    Q_ASSERT(accessible);
++
++    QAccessibleAttributesInterface *attributesIface = accessible->attributesInterface();
++    if (!attributesIface)
++        return;
++
++    const QVariant valueVariant = attributesIface->attributeValue(attribute);
++    if (!valueVariant.isValid())
++        return;
++
++    Q_ASSERT(valueVariant.canConvert<int>());
++    *pRetVal = QComVariant{ long(valueVariant.toInt()) }.release();
++}
++
+ void QWindowsUiaMainProvider::setStyle(QAccessibleInterface *accessible, VARIANT *pRetVal)
+ {
+     Q_ASSERT(accessible);
+@@ -569,6 +595,19 @@ HRESULT QWindowsUiaMainProvider::GetPropertyValue(PROPERTYID idProp, VARIANT *pR
+         *pRetVal = QComVariant{ long(lcid) }.release();
+         break;
+     }
++    case UIA_LevelPropertyId:
++        // Structural depth, e.g. of an item in a tree. Headings convey
++        // their level through the heading text style and the "level"
++        // ARIA property instead.
++        if (accessible->role() != QAccessible::Role::Heading)
++            setIntAttribute(accessible, QAccessible::Attribute::Level, pRetVal);
++        break;
++    case UIA_PositionInSetPropertyId:
++        setIntAttribute(accessible, QAccessible::Attribute::PositionInSet, pRetVal);
++        break;
++    case UIA_SizeOfSetPropertyId:
++        setIntAttribute(accessible, QAccessible::Attribute::SizeOfSet, pRetVal);
++        break;
+     case UIA_DescribedByPropertyId:
+         fillVariantArrayForRelation(accessible, QAccessible::DescriptionFor, pRetVal);
+         break;
+diff --git a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.h b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.h
+index 8f631c7aa69..442f350d188 100644
+--- a/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.h
++++ b/src/plugins/platforms/windows/uiautomation/qwindowsuiamainprovider.h
+@@ -64,6 +64,8 @@ private:
+     static void setLabelledBy(QAccessibleInterface *accessible, VARIANT *pRetVal);
+     static void fillVariantArrayForRelation(QAccessibleInterface *accessible, QAccessible::Relation relation, VARIANT *pRetVal);
+     static void setAriaProperties(QAccessibleInterface *accessible, VARIANT *pRetVal);
++    static void setIntAttribute(QAccessibleInterface *accessible,
++                                QAccessible::Attribute attribute, VARIANT *pRetVal);
+     static void setStyle(QAccessibleInterface *accessible, VARIANT *pRetVal);
+     /** Returns the UIA style ID for a heading level from 1 to 9. */
+     static int styleIdForHeadingLevel(int headingLevel);

--- a/qtbase_6.11.2/0048-backport-atspi-set-attributes.patch
+++ b/qtbase_6.11.2/0048-backport-atspi-set-attributes.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+Date: Tue, 8 Sep 2026 12:00:00
+Subject: [PATCH] backported the AT-SPI mapping of the PositionInSet/SizeOfSet attributes
+
+Backport of the Qt 6.13 change e67c4ebbd2d7268a51d54fca2dd40225915ec960
+(QTBUG-149577): the AT-SPI bridge forwards the PositionInSet and SizeOfSet
+attributes, added in 64a9bd4c2291359a125b406bff43d3ecace07b42 and
+backported in 0047, as the "posinset" and "setsize" object attributes,
+the way the Core Accessibility API Mappings specify for aria-posinset and
+aria-setsize, so assistive technology on Linux can report the position of
+an element within its set ("2 of 10") the same way as on Windows.
+
+diff --git a/src/gui/accessible/linux/atspiadaptor.cpp b/src/gui/accessible/linux/atspiadaptor.cpp
+index dae8343..11f4c78 100644
+--- a/src/gui/accessible/linux/atspiadaptor.cpp
++++ b/src/gui/accessible/linux/atspiadaptor.cpp
+@@ -2470,6 +2470,14 @@ QSpiAttributeSet AtSpiAdaptor::getAttributes(QAccessibleInterface *interface)
+             Q_ASSERT(value.canConvert<int>());
+             set.insert(QStringLiteral("level"), QString::number(value.toInt()));
+             break;
++        case QAccessible::Attribute::PositionInSet:
++            Q_ASSERT(value.canConvert<int>());
++            set.insert(QStringLiteral("posinset"), QString::number(value.toInt()));
++            break;
++        case QAccessible::Attribute::SizeOfSet:
++            Q_ASSERT(value.canConvert<int>());
++            set.insert(QStringLiteral("setsize"), QString::number(value.toInt()));
++            break;
+         default:
+             break;
+         }


### PR DESCRIPTION
Backport of the qtbase change 64a9bd4c2291359a125b406bff43d3ecace07b42, merged into dev and released in Qt 6.13 (QTBUG-149577, https://codereview.qt-project.org/c/qt/qtbase/+/764810): QAccessible::Attribute gains PositionInSet and SizeOfSet, so an accessible element can report its 1-based position within its set of siblings and the size of that set through QAccessibleAttributesInterface, matching aria-posinset / aria-setsize. The Windows UIA bridge maps them to UIA_PositionInSetPropertyId / UIA_SizeOfSetPropertyId, and the existing Level attribute to UIA_LevelPropertyId for non-heading elements. That is what lets a screen reader say "2 of 10" on a painted list item, the way it does on the lists that are real widgets.

- qtbase_6.11.2/0047 is the upstream commit cherry-picked onto v6.11.2 as is, documentation included, so it can be dropped unchanged once the builds move to Qt 6.13.
- qtbase_5.15.19/0042 is the same change in the 5.15 sources: only the two enum values and the bridge cases are left, since 0038 already backported the attributes interface itself. It carries no documentation because 5.15 documents nothing about that enum - 0038 added it undocumented as well. 5.15 will never get the change upstream, so this one stays as long as the Windows build is on 5.15.

- qtbase_6.11.2/0048 is the AT-SPI side, https://codereview.qt-project.org/c/qt/qtbase/+/765924 (e67c4ebbd2d7268a51d54fca2dd40225915ec960, also merged into dev for Qt 6.13), cherry-picked as is: the Linux bridge forwards the two attributes as the "posinset" / "setsize" object attributes, so Orca gets the same "n of N". It needs 0047 for the enum values.

The Qt widgets that will report the attributes themselves are https://codereview.qt-project.org/c/qt/qtbase/+/765926, still under review, and not needed by Telegram.

Used by desktop-app/lib_ui#359, where a painted list item reports its position, and verified with NVDA on Windows 10 against a 5.15 build with 0042: the chat list, the folder tabs, the countries and languages lists and the message lists all announce "n of N" after the row name.


